### PR TITLE
div 태그에 border 임시 설정

### DIFF
--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -5,7 +5,7 @@ export default function Layout() {
   return (
     <div className="flex min-h-screen flex-col items-center">
       <header className="fixed w-full border border-black">헤더</header>
-      <div className="flex min-w-[1280px] flex-1 flex-col items-center border border-black pt-6">
+      <div className="flex min-w-[1280px] flex-1 flex-col items-center pt-6">
         <Outlet />
         <img src={vector} className="fixed left-0 top-[-20px] -z-50" />
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -8,4 +8,7 @@
     font-family: "Inter";
     font-size: 24px;
   }
+  div {
+    border: 1px solid black;
+  }
 }


### PR DESCRIPTION
## 이슈와 연결하기

Issue Number: #6 

<br>

## 무엇이 추가 되었나요?

<br>

`div` 태그에 임시로 `border` 를 설정해 `div` 의 가독성을 높였습니다. 추후 스타일링 시 삭제하면 됩니다.

## 기타 정보

<br>