### PR TITLE
탭 메뉴 컴포넌트 프로토타입 구현 

### DIFF
--- a/src/components/TapMenu/MenuButton.tsx
+++ b/src/components/TapMenu/MenuButton.tsx
@@ -1,0 +1,32 @@
+import { CiCircleCheck, CiWarning, CiTrophy, CiCalendar, CiCircleInfo } from "react-icons/ci";
+import { LuHome } from "react-icons/lu";
+
+export default function MenuButton({ menu, onClick }: { menu: string; onClick: () => void }) {
+  const getMenuIcon = (menu: string) => {
+    switch (menu) {
+      case "예매완료":
+        return <CiCircleCheck />;
+      case "예매취소":
+        return <CiWarning />;
+      case "나의 팀":
+        return <CiTrophy />;
+      case "예매일정":
+        return <CiCalendar />;
+      case "홈구장 안내":
+        return <LuHome />;
+      case "예매정보":
+        return <CiCircleInfo />;
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="button-hover flex items-center justify-center rounded-lg border bg-white px-[45px] py-[12px] text-[16px] text-black transition-colors duration-300"
+    >
+      <span className="mr-2">{getMenuIcon(menu)}</span>
+      {menu}
+    </button>
+  );
+}

--- a/src/components/TapMenu/TapMenu.tsx
+++ b/src/components/TapMenu/TapMenu.tsx
@@ -1,0 +1,5 @@
+import { ReactNode } from "react";
+
+export default function TapMenu({ children }: { children: ReactNode }) {
+  return <div className="flex gap-4">{children}</div>;
+}

--- a/src/components/TapMenu/TapMenu.tsx
+++ b/src/components/TapMenu/TapMenu.tsx
@@ -1,5 +1,0 @@
-import { ReactNode } from "react";
-
-export default function TapMenu({ children }: { children: ReactNode }) {
-  return <div className="flex gap-4">{children}</div>;
-}

--- a/src/index.css
+++ b/src/index.css
@@ -12,3 +12,6 @@
     border: 1px solid black;
   }
 }
+.button-hover:hover {
+  @apply bg-Accent text-foreground;
+}


### PR DESCRIPTION
## 이슈와 연결하기

Issue Number: #7

<br>

## 무엇이 추가 되었나요?

탭 메뉴 컴포넌트의 프로토타입을 구현했습니다.

<br>

## 기타 정보

<br>


- 평소
<img width="1187" alt="스크린샷 2024-08-05 오후 3 07 14" src="https://github.com/user-attachments/assets/acbf6dbf-b9e6-47bd-9baa-3577b81bf151">

- 호버했을 때
<img width="1208" alt="스크린샷 2024-08-05 오후 3 07 19" src="https://github.com/user-attachments/assets/8baeb55e-1c08-4339-9121-9eebebc2e83c">

- 일단 버튼을 다음과 같이 사용한다고 가정해서 만들었습니다. 혹시 더 좋은 방법이 있으시다면 알려주세요!
```js
import Button from "../components/Button";
import MenuButton from "../components/TapMenu/MenuButton";
import TapMenu from "../components/TapMenu/TapMenu";

export default function Home() {

  function handleButtonClick() {
    console.log("눌렸어요~ 나중에 여기 메뉴 작동을 작성해주시면 됩니다~");
  }
  return (
    <div>
      홈 페이지
      <TapMenu>
        <MenuButton menu="예매완료" onClick={handleButtonClick} />
        <MenuButton menu="예매취소" onClick={handleButtonClick} />
        <MenuButton menu="나의 팀" onClick={handleButtonClick} />
      </TapMenu>
      <Button content="테스트용" />
    </div>
  );
}
```