### PR TITLE
SignUp 페이지 구현

### DIFF
--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -8,7 +8,9 @@ export default function Layout() {
     <div className="flex min-h-screen flex-col items-center">
       <Header />
       <div className="flex max-w-[1280px] flex-1 flex-col items-center pt-[80px]">
-        <Outlet />
+        <main className="w-full">
+          <Outlet />
+        </main>
         <img src={vector} className="fixed left-0 top-[-20px] -z-50" />
       </div>
       <Footer />

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,8 +1,9 @@
 interface ButtonProps {
   content: string;
+  isValid?: boolean;
 }
 
-const Button = ({ content }: ButtonProps) => {
+const Button = ({ content, isValid }: ButtonProps) => {
   const getStyles = (content: string) => {
     switch (content) {
       case "로그인":
@@ -18,8 +19,9 @@ const Button = ({ content }: ButtonProps) => {
         };
       case "회원가입 하기":
         return {
-          base: "bg-Accent text-foreground text-[16px] w-full px-3 py-2 mt-4",
-          hover: "hover:bg-button-hovered hover:text-foreground hover:border-Accent",
+          base: "bg-Accent text-foreground text-[16px] w-full px-3 py-2 mt-4 ",
+          hover: "hover:bg-button-hovered ",
+          disabled: "disabled:bg-disabled-button disabled:cursor-not-allowed",
         };
       case "block":
         return {
@@ -43,7 +45,8 @@ const Button = ({ content }: ButtonProps) => {
   return (
     <button
       type={content === "회원가입 하기" ? "submit" : "button"}
-      className={`${styles.base} border ${styles.hover} flex items-center justify-center rounded-[10px] transition-all duration-300`}
+      disabled={isValid === false}
+      className={`${styles.base} border ${styles.hover} ${styles.disabled} flex items-center justify-center rounded-[10px] transition-all duration-300`}
     >
       {content}
     </button>

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -16,6 +16,11 @@ const Button = ({ content }: ButtonProps) => {
           base: "border-0",
           hover: "hover:text-Accent",
         };
+      case "회원가입 하기":
+        return {
+          base: "bg-Accent text-foreground text-[16px] w-full px-3 py-2 mt-4",
+          hover: "hover:bg-button-hovered hover:text-foreground hover:border-Accent",
+        };
       case "block":
         return {
           base: "bg-borders text-text-primary border-borders",
@@ -37,7 +42,7 @@ const Button = ({ content }: ButtonProps) => {
 
   return (
     <button
-      type="button"
+      type={content === "회원가입 하기" ? "submit" : "button"}
       className={`${styles.base} border ${styles.hover} flex items-center justify-center rounded-[10px] transition-all duration-300`}
     >
       {content}

--- a/src/components/Header.tsx/HeaderNav.tsx
+++ b/src/components/Header.tsx/HeaderNav.tsx
@@ -3,7 +3,9 @@ export default function HeaderNav() {
   return (
     <nav className="m-auto flex w-60 flex-row justify-between">
       {menu.map((el) => (
-        <div className="text-[18px] font-medium">{el}</div>
+        <div key={el} className="text-[18px] font-medium">
+          {el}
+        </div>
       ))}
     </nav>
   );

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import useInput from "../hooks/useInput";
 
 type InputType = "text" | "email" | "password";
 
@@ -12,7 +11,6 @@ interface InputComponentProps {
 }
 
 export default function Input({ label, type = "text", register }: InputComponentProps) {
-  const inputProps = useInput();
   const [showPassword, setShowPassword] = useState(false);
 
   const handleToggleShowPassword = () => {
@@ -24,7 +22,6 @@ export default function Input({ label, type = "text", register }: InputComponent
       <div className="relative">
         <input
           type={type === "password" && showPassword ? "text" : type}
-          {...inputProps}
           {...register}
           className="w-full appearance-none rounded-[15px] px-3 py-2 text-[16px] transition-colors duration-300 focus:bg-focused-input-background focus:outline-none"
           placeholder={label}

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -3,12 +3,15 @@ import useInput from "../hooks/useInput";
 
 type InputType = "text" | "email" | "password";
 
+import { UseFormRegisterReturn } from "react-hook-form";
+
 interface InputComponentProps {
   label: string;
   type?: InputType;
+  register?: UseFormRegisterReturn;
 }
 
-export default function Input({ label, type = "text" }: InputComponentProps) {
+export default function Input({ label, type = "text", register }: InputComponentProps) {
   const inputProps = useInput();
   const [showPassword, setShowPassword] = useState(false);
 
@@ -22,6 +25,7 @@ export default function Input({ label, type = "text" }: InputComponentProps) {
         <input
           type={type === "password" && showPassword ? "text" : type}
           {...inputProps}
+          {...register}
           className="w-full appearance-none rounded-[15px] px-3 py-2 text-[16px] transition-colors duration-300 focus:bg-focused-input-background focus:outline-none"
           placeholder={label}
         />

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,9 +1,11 @@
 import { useState } from "react";
 import useInput from "../hooks/useInput";
 
+type InputType = "text" | "email" | "password";
+
 interface InputComponentProps {
   label: string;
-  type?: string;
+  type?: InputType;
 }
 
 export default function Input({ label, type = "text" }: InputComponentProps) {
@@ -15,12 +17,12 @@ export default function Input({ label, type = "text" }: InputComponentProps) {
   };
 
   return (
-    <div className="my-2">
+    <div className="my-1">
       <div className="relative">
         <input
-          type={type === "password" && showPassword ? "password" : "text"}
+          type={type === "password" && showPassword ? "text" : type}
           {...inputProps}
-          className="focus:bg-focused-input-background w-48 appearance-none rounded-[15px] px-3 py-2 text-[16px] transition-colors duration-300 focus:outline-none"
+          className="w-full appearance-none rounded-[15px] px-3 py-2 text-[16px] transition-colors duration-300 focus:bg-focused-input-background focus:outline-none"
           placeholder={label}
         />
         {type === "password" && (
@@ -28,7 +30,7 @@ export default function Input({ label, type = "text" }: InputComponentProps) {
             className="absolute inset-y-0 right-0 flex cursor-pointer items-center pr-3"
             onClick={handleToggleShowPassword}
           >
-            {showPassword ? (
+            {!showPassword ? (
               <svg
                 width="29"
                 height="23"
@@ -38,8 +40,8 @@ export default function Input({ label, type = "text" }: InputComponentProps) {
               >
                 <path
                   d="M13.5375 7.5L17.5 11.45V11.25C17.5 10.2554 17.1049 9.30161 16.4017 8.59835C15.6984 7.89509 14.7446 7.5 13.75 7.5H13.5375ZM8.1625 8.5L10.1 10.4375C10.0375 10.7 10 10.9625 10 11.25C10 12.2446 10.3951 13.1984 11.0983 13.9017C11.8016 14.6049 12.7554 15 13.75 15C14.025 15 14.3 14.9625 14.5625 14.9L16.5 16.8375C15.6625 17.25 14.7375 17.5 13.75 17.5C12.0924 17.5 10.5027 16.8415 9.33058 15.6694C8.15848 14.4973 7.5 12.9076 7.5 11.25C7.5 10.2625 7.75 9.3375 8.1625 8.5ZM1.25 1.5875L4.1 4.4375L4.6625 5C2.6 6.625 0.975 8.75 0 11.25C2.1625 16.7375 7.5 20.625 13.75 20.625C15.6875 20.625 17.5375 20.25 19.225 19.575L19.7625 20.1L23.4125 23.75L25 22.1625L2.8375 0M13.75 5C15.4076 5 16.9973 5.65848 18.1694 6.83058C19.3415 8.00269 20 9.5924 20 11.25C20 12.05 19.8375 12.825 19.55 13.525L23.2125 17.1875C25.0875 15.625 26.5875 13.575 27.5 11.25C25.3375 5.7625 20 1.875 13.75 1.875C12 1.875 10.325 2.1875 8.75 2.75L11.4625 5.4375C12.175 5.1625 12.9375 5 13.75 5Z"
-                  fill="#222222"
-                  fill-opacity="0.5"
+                  fill="#DBDBDB"
+                  fillOpacity=""
                 />
               </svg>
             ) : (
@@ -52,8 +54,8 @@ export default function Input({ label, type = "text" }: InputComponentProps) {
               >
                 <path
                   d="M15 11.25C14.0054 11.25 13.0516 11.6451 12.3483 12.3483C11.6451 13.0516 11.25 14.0054 11.25 15C11.25 15.9946 11.6451 16.9484 12.3483 17.6517C13.0516 18.3549 14.0054 18.75 15 18.75C15.9946 18.75 16.9484 18.3549 17.6517 17.6517C18.3549 16.9484 18.75 15.9946 18.75 15C18.75 14.0054 18.3549 13.0516 17.6517 12.3483C16.9484 11.6451 15.9946 11.25 15 11.25ZM15 21.25C13.3424 21.25 11.7527 20.5915 10.5806 19.4194C9.40848 18.2473 8.75 16.6576 8.75 15C8.75 13.3424 9.40848 11.7527 10.5806 10.5806C11.7527 9.40848 13.3424 8.75 15 8.75C16.6576 8.75 18.2473 9.40848 19.4194 10.5806C20.5915 11.7527 21.25 13.3424 21.25 15C21.25 16.6576 20.5915 18.2473 19.4194 19.4194C18.2473 20.5915 16.6576 21.25 15 21.25ZM15 5.625C8.75 5.625 3.4125 9.5125 1.25 15C3.4125 20.4875 8.75 24.375 15 24.375C21.25 24.375 26.5875 20.4875 28.75 15C26.5875 9.5125 21.25 5.625 15 5.625Z"
-                  fill="#222222"
-                  fill-opacity="0.5"
+                  fill="#DBDBDB"
+                  fillOpacity=""
                 />
               </svg>
             )}

--- a/src/components/InputErrorMessage.tsx
+++ b/src/components/InputErrorMessage.tsx
@@ -1,0 +1,13 @@
+import { FieldError } from "react-hook-form";
+
+export default function InputErrorMessage({ error }: { error: FieldError | undefined }) {
+  return (
+    <div
+      className={`transition-all duration-300 ease-in-out ${
+        error ? "max-h-10 opacity-100" : "max-h-0 opacity-0"
+      }`}
+    >
+      {error && <p className="ml-2 text-[14px] text-Accent">{error.message}</p>}
+    </div>
+  );
+}

--- a/src/components/MainMatch/Timer.tsx
+++ b/src/components/MainMatch/Timer.tsx
@@ -63,9 +63,7 @@ export default function Timer({ mainMatchStartTime }: { mainMatchStartTime: stri
   return (
     <div className="flex justify-center">
       {isTimeUp ? (
-        <span className="flex h-20 items-center border border-yellow-700">
-          예매 일정이 지났습니다!
-        </span>
+        <span className="flex h-20 items-center">예매 일정이 지났습니다!</span>
       ) : (
         <>
           {Object.entries(leftTime).map(([unit, value]) => (

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -4,7 +4,7 @@ import WeeklyMatches from "../components/WeeklyMatches/WeeklyMatches";
 
 export default function Home() {
   return (
-    <main className="w-full">
+    <div className="mb-24">
       <section className="my-8 flex items-center justify-between text-center">
         <MainMatch />
         <div>
@@ -14,6 +14,6 @@ export default function Home() {
       <section>
         <WeeklyMatches />
       </section>
-    </main>
+    </div>
   );
 }

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -2,6 +2,7 @@ import { Link } from "react-router-dom";
 import Input from "../components/Input";
 import Button from "../components/Button";
 import { SubmitHandler, useForm } from "react-hook-form";
+import SignUpErrorMessage from "../components/SignUpErrorMessage";
 
 interface SignUpForm {
   email: string;
@@ -22,21 +23,21 @@ const validationRules = {
     required: "이름을 입력해주세요.",
     pattern: {
       value: /^[a-zA-Z가-힣]{2,}$/,
-      message: "이름은 최소 두 글자 이상의 한글 또는 영문만 입력 가능합니다.",
+      message: "이름은 두 글자 이상의 한글, 영문만 입력 가능합니다.",
     },
   },
   phoneNumber: {
     required: "전화번호를 입력해주세요.",
     pattern: {
       value: /^010-\d{4}-\d{4}$/,
-      message: "유효한 전화번호 형식을 입력해주세요. (예: 010-1234-5678)",
+      message: "유효한 번호를 입력해주세요. (예: 010-0000-0000)",
     },
   },
   password: {
     required: "비밀번호를 입력해주세요.",
     pattern: {
       value: /(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}/,
-      message: "비밀번호는 영문, 숫자, 특수문자를 포함한 최소 8자 이상이어야 합니다.",
+      message: "영문, 숫자, 특수문자 포함 최소 8자 이상이어야 합니다.",
     },
   },
   passwordConfirmation: {
@@ -53,8 +54,10 @@ export default function SignUp() {
     handleSubmit,
     getValues,
   } = useForm<SignUpForm>({ mode: "onBlur" });
+
   const onSubmit: SubmitHandler<SignUpForm> = (data) => {
     const { passwordConfirmation, ...formData } = data;
+    // 회원가입 양식 제출 로직
     console.log(passwordConfirmation, formData);
   };
 
@@ -70,13 +73,17 @@ export default function SignUp() {
       </span>
       <form className="my-4 flex flex-col" onSubmit={handleSubmit(onSubmit)}>
         <Input label="이메일" type="email" register={register("email", validationRules.email)} />
+        <SignUpErrorMessage error={errors.email} />
         <Input label="이름" register={register("name", validationRules.name)} />
-        <Input label="전화번호" register={register("phoneNumber", validationRules.phoneNumber)} />
+        <SignUpErrorMessage error={errors.name} />
+        <Input label="휴대전화" register={register("phoneNumber", validationRules.phoneNumber)} />
+        <SignUpErrorMessage error={errors.phoneNumber} />
         <Input
           label="비밀번호"
           type="password"
           register={register("password", validationRules.password)}
         />
+        <SignUpErrorMessage error={errors.password} />
         <Input
           label="비밀번호 재확인"
           type="password"
@@ -85,6 +92,7 @@ export default function SignUp() {
             validate: (value) => validationRules.passwordConfirmation.validate(value, getValues),
           })}
         />
+        <SignUpErrorMessage error={errors.passwordConfirmation} />
         <Button content="회원가입 하기" />
       </form>
     </section>

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -14,39 +14,49 @@ const validationRules = {
   email: {
     required: "이메일을 입력해주세요.",
     pattern: {
-      value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+      value: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
       message: "유효한 이메일 형식을 입력해주세요.",
     },
   },
   name: {
     required: "이름을 입력해주세요.",
+    pattern: {
+      value: /^[a-zA-Z가-힣]{2,}$/,
+      message: "이름은 최소 두 글자 이상의 한글 또는 영문만 입력 가능합니다.",
+    },
   },
   phoneNumber: {
     required: "전화번호를 입력해주세요.",
     pattern: {
-      value: /^[0-9]{10,11}$/,
-      message: "유효한 전화번호를 입력해주세요.",
+      value: /^010-\d{4}-\d{4}$/,
+      message: "유효한 전화번호 형식을 입력해주세요. (예: 010-1234-5678)",
     },
   },
   password: {
     required: "비밀번호를 입력해주세요.",
-    minLength: {
-      value: 8,
-      message: "비밀번호는 최소 8자 이상이어야 합니다.",
+    pattern: {
+      value: /(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}/,
+      message: "비밀번호는 영문, 숫자, 특수문자를 포함한 최소 8자 이상이어야 합니다.",
     },
+  },
+  passwordConfirmation: {
+    required: "비밀번호를 재확인해주세요.",
+    validate: (value: string, getValues: () => SignUpForm) =>
+      value === getValues().password || "비밀번호가 일치하지 않습니다.",
   },
 };
 
 export default function SignUp() {
   const {
     register,
-    handleSubmit,
     formState: { errors },
+    handleSubmit,
     getValues,
-    watch,
-  } = useForm<SignUpForm>();
-  const formValues = watch();
-  const onSubmit: SubmitHandler<SignUpForm> = () => console.log(formValues);
+  } = useForm<SignUpForm>({ mode: "onBlur" });
+  const onSubmit: SubmitHandler<SignUpForm> = (data) => {
+    const { passwordConfirmation, ...formData } = data;
+    console.log(passwordConfirmation, formData);
+  };
 
   return (
     <div className="flex w-full flex-col justify-center pt-12">
@@ -61,34 +71,21 @@ export default function SignUp() {
       <section className="my-4">
         <form className="flex flex-col" onSubmit={handleSubmit(onSubmit)}>
           <Input label="이메일" type="email" register={register("email", validationRules.email)} />
-          {errors.email && <p className="text-red-500">{errors.email.message}</p>}
-
           <Input label="이름" register={register("name", validationRules.name)} />
-          {errors.name && <p className="text-red-500">{errors.name.message}</p>}
-
           <Input label="전화번호" register={register("phoneNumber", validationRules.phoneNumber)} />
-          {errors.phoneNumber && <p className="text-red-500">{errors.phoneNumber.message}</p>}
-
           <Input
             label="비밀번호"
             type="password"
             register={register("password", validationRules.password)}
           />
-          {errors.password && <p className="text-red-500">{errors.password.message}</p>}
-
           <Input
             label="비밀번호 재확인"
             type="password"
             register={register("passwordConfirmation", {
-              required: "비밀번호를 재확인해주세요.",
-              validate: (value) =>
-                value === getValues("password") || "비밀번호가 일치하지 않습니다.",
+              ...validationRules.passwordConfirmation,
+              validate: (value) => validationRules.passwordConfirmation.validate(value, getValues),
             })}
           />
-          {errors.passwordConfirmation && (
-            <p className="text-red-500">{errors.passwordConfirmation.message}</p>
-          )}
-
           <Button content="회원가입 하기" />
         </form>
       </section>

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -59,7 +59,7 @@ export default function SignUp() {
   };
 
   return (
-    <div className="flex w-full flex-col justify-center pt-12">
+    <section className="flex w-full flex-col justify-center pt-12">
       <h1 className="text-2xl font-bold">회원가입</h1>
       <span>
         이미 회원이신가요?{" "}
@@ -68,27 +68,25 @@ export default function SignUp() {
         </Link>{" "}
         하세요.
       </span>
-      <section className="my-4">
-        <form className="flex flex-col" onSubmit={handleSubmit(onSubmit)}>
-          <Input label="이메일" type="email" register={register("email", validationRules.email)} />
-          <Input label="이름" register={register("name", validationRules.name)} />
-          <Input label="전화번호" register={register("phoneNumber", validationRules.phoneNumber)} />
-          <Input
-            label="비밀번호"
-            type="password"
-            register={register("password", validationRules.password)}
-          />
-          <Input
-            label="비밀번호 재확인"
-            type="password"
-            register={register("passwordConfirmation", {
-              ...validationRules.passwordConfirmation,
-              validate: (value) => validationRules.passwordConfirmation.validate(value, getValues),
-            })}
-          />
-          <Button content="회원가입 하기" />
-        </form>
-      </section>
-    </div>
+      <form className="my-4 flex flex-col" onSubmit={handleSubmit(onSubmit)}>
+        <Input label="이메일" type="email" register={register("email", validationRules.email)} />
+        <Input label="이름" register={register("name", validationRules.name)} />
+        <Input label="전화번호" register={register("phoneNumber", validationRules.phoneNumber)} />
+        <Input
+          label="비밀번호"
+          type="password"
+          register={register("password", validationRules.password)}
+        />
+        <Input
+          label="비밀번호 재확인"
+          type="password"
+          register={register("passwordConfirmation", {
+            ...validationRules.passwordConfirmation,
+            validate: (value) => validationRules.passwordConfirmation.validate(value, getValues),
+          })}
+        />
+        <Button content="회원가입 하기" />
+      </form>
+    </section>
   );
 }

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -53,7 +53,7 @@ export default function SignUp() {
     formState: { errors },
     handleSubmit,
     getValues,
-  } = useForm<SignUpForm>({ mode: "onBlur" });
+  } = useForm<SignUpForm>({ mode: "onTouched" });
 
   const onSubmit: SubmitHandler<SignUpForm> = (data) => {
     const { passwordConfirmation, ...formData } = data;

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -3,17 +3,50 @@ import Input from "../components/Input";
 import Button from "../components/Button";
 import { SubmitHandler, useForm } from "react-hook-form";
 
-interface SignUpFormInput {
+interface SignUpForm {
   email: string;
   name: string;
   phoneNumber: string;
   password: string;
   passwordConfirmation: string;
 }
+const validationRules = {
+  email: {
+    required: "이메일을 입력해주세요.",
+    pattern: {
+      value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+      message: "유효한 이메일 형식을 입력해주세요.",
+    },
+  },
+  name: {
+    required: "이름을 입력해주세요.",
+  },
+  phoneNumber: {
+    required: "전화번호를 입력해주세요.",
+    pattern: {
+      value: /^[0-9]{10,11}$/,
+      message: "유효한 전화번호를 입력해주세요.",
+    },
+  },
+  password: {
+    required: "비밀번호를 입력해주세요.",
+    minLength: {
+      value: 8,
+      message: "비밀번호는 최소 8자 이상이어야 합니다.",
+    },
+  },
+};
 
 export default function SignUp() {
-  const { register, handleSubmit } = useForm<SignUpFormInput>();
-  const onSubmit: SubmitHandler<SignUpFormInput> = (data) => console.log(data);
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    getValues,
+    watch,
+  } = useForm<SignUpForm>();
+  const formValues = watch();
+  const onSubmit: SubmitHandler<SignUpForm> = () => console.log(formValues);
 
   return (
     <div className="flex w-full flex-col justify-center pt-12">
@@ -27,15 +60,35 @@ export default function SignUp() {
       </span>
       <section className="my-4">
         <form className="flex flex-col" onSubmit={handleSubmit(onSubmit)}>
-          <Input label="이메일" type="email" register={register("email")} />
-          <Input label="이름" register={register("name")} />
-          <Input label="전화번호" register={register("phoneNumber")} />
-          <Input label="비밀번호" type="password" register={register("password")} />
+          <Input label="이메일" type="email" register={register("email", validationRules.email)} />
+          {errors.email && <p className="text-red-500">{errors.email.message}</p>}
+
+          <Input label="이름" register={register("name", validationRules.name)} />
+          {errors.name && <p className="text-red-500">{errors.name.message}</p>}
+
+          <Input label="전화번호" register={register("phoneNumber", validationRules.phoneNumber)} />
+          {errors.phoneNumber && <p className="text-red-500">{errors.phoneNumber.message}</p>}
+
+          <Input
+            label="비밀번호"
+            type="password"
+            register={register("password", validationRules.password)}
+          />
+          {errors.password && <p className="text-red-500">{errors.password.message}</p>}
+
           <Input
             label="비밀번호 재확인"
             type="password"
-            register={register("passwordConfirmation")}
+            register={register("passwordConfirmation", {
+              required: "비밀번호를 재확인해주세요.",
+              validate: (value) =>
+                value === getValues("password") || "비밀번호가 일치하지 않습니다.",
+            })}
           />
+          {errors.passwordConfirmation && (
+            <p className="text-red-500">{errors.passwordConfirmation.message}</p>
+          )}
+
           <Button content="회원가입 하기" />
         </form>
       </section>

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -1,8 +1,20 @@
 import { Link } from "react-router-dom";
 import Input from "../components/Input";
 import Button from "../components/Button";
+import { SubmitHandler, useForm } from "react-hook-form";
+
+interface SignUpFormInput {
+  email: string;
+  name: string;
+  phoneNumber: string;
+  password: string;
+  passwordConfirmation: string;
+}
 
 export default function SignUp() {
+  const { register, handleSubmit } = useForm<SignUpFormInput>();
+  const onSubmit: SubmitHandler<SignUpFormInput> = (data) => console.log(data);
+
   return (
     <div className="flex w-full flex-col justify-center pt-12">
       <h1 className="text-2xl font-bold">회원가입</h1>
@@ -14,12 +26,16 @@ export default function SignUp() {
         하세요.
       </span>
       <section className="my-4">
-        <form className="flex flex-col">
-          <Input label="이메일" />
-          <Input label="이름" />
-          <Input label="전화번호" />
-          <Input label="비밀번호" type="password" />
-          <Input label="비밀번호 재확인" type="password" />
+        <form className="flex flex-col" onSubmit={handleSubmit(onSubmit)}>
+          <Input label="이메일" type="email" register={register("email")} />
+          <Input label="이름" register={register("name")} />
+          <Input label="전화번호" register={register("phoneNumber")} />
+          <Input label="비밀번호" type="password" register={register("password")} />
+          <Input
+            label="비밀번호 재확인"
+            type="password"
+            register={register("passwordConfirmation")}
+          />
           <Button content="회원가입 하기" />
         </form>
       </section>

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -2,7 +2,7 @@ import { Link } from "react-router-dom";
 import Input from "../components/Input";
 import Button from "../components/Button";
 import { SubmitHandler, useForm } from "react-hook-form";
-import SignUpErrorMessage from "../components/SignUpErrorMessage";
+import InputErrorMessage from "../components/InputErrorMessage";
 
 interface SignUpForm {
   email: string;
@@ -50,7 +50,7 @@ const validationRules = {
 export default function SignUp() {
   const {
     register,
-    formState: { errors },
+    formState: { errors, isValid },
     handleSubmit,
     getValues,
   } = useForm<SignUpForm>({ mode: "onTouched" });
@@ -73,17 +73,17 @@ export default function SignUp() {
       </span>
       <form className="my-4 flex flex-col" onSubmit={handleSubmit(onSubmit)}>
         <Input label="이메일" type="email" register={register("email", validationRules.email)} />
-        <SignUpErrorMessage error={errors.email} />
+        <InputErrorMessage error={errors.email} />
         <Input label="이름" register={register("name", validationRules.name)} />
-        <SignUpErrorMessage error={errors.name} />
+        <InputErrorMessage error={errors.name} />
         <Input label="휴대전화" register={register("phoneNumber", validationRules.phoneNumber)} />
-        <SignUpErrorMessage error={errors.phoneNumber} />
+        <InputErrorMessage error={errors.phoneNumber} />
         <Input
           label="비밀번호"
           type="password"
           register={register("password", validationRules.password)}
         />
-        <SignUpErrorMessage error={errors.password} />
+        <InputErrorMessage error={errors.password} />
         <Input
           label="비밀번호 재확인"
           type="password"
@@ -92,7 +92,7 @@ export default function SignUp() {
             validate: (value) => validationRules.passwordConfirmation.validate(value, getValues),
           })}
         />
-        <SignUpErrorMessage error={errors.passwordConfirmation} />
+        <InputErrorMessage error={errors.passwordConfirmation} />
         <Button content="회원가입 하기" />
       </form>
     </section>

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -93,7 +93,7 @@ export default function SignUp() {
           })}
         />
         <InputErrorMessage error={errors.passwordConfirmation} />
-        <Button content="회원가입 하기" />
+        <Button content="회원가입 하기" isValid={isValid} />
       </form>
     </section>
   );

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -1,3 +1,28 @@
-export default function Home() {
-  return <div>회원가입 페이지</div>;
+import { Link } from "react-router-dom";
+import Input from "../components/Input";
+import Button from "../components/Button";
+
+export default function SignUp() {
+  return (
+    <div className="flex w-full flex-col justify-center pt-12">
+      <h1 className="text-2xl font-bold">회원가입</h1>
+      <span>
+        이미 회원이신가요?{" "}
+        <Link className="text-Accent hover:text-button-hovered" to={"/login"}>
+          로그인
+        </Link>{" "}
+        하세요.
+      </span>
+      <section className="my-4">
+        <form className="flex flex-col">
+          <Input label="이메일" />
+          <Input label="이름" />
+          <Input label="전화번호" />
+          <Input label="비밀번호" type="password" />
+          <Input label="비밀번호 재확인" type="password" />
+          <Button content="회원가입 하기" />
+        </form>
+      </section>
+    </div>
+  );
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,6 +12,7 @@ export default {
         "text-secondary": "rgba(34, 34, 34, 0.5)",
         borders: "#DBDBDB",
         "focused-input-background": "rgba(219, 219, 219, 0.5)",
+        "disabled-button": "rgb(238, 161, 169)",
       },
     },
   },


### PR DESCRIPTION
## 이슈와 연결하기

Issue Number: #8 

<br>

## 무엇이 추가 되었나요?
- SignUp 페이지 구현
  - 회원가입 form 구현
  - 회원가입 form에 리액트 훅 폼을 이용한 유효성 검증 구현
  - 유효성 검증을 통과하지 못했을 때 보여줄 InputErrorMessage 구현
  - Button 컴포넌트 종류에 '회원가입 하기' 추가
  - Button 컴포넌트에 조건부 disabled 속성 추가
  - tailiwnd.config에 disabled 된 버튼 색상 추가
- 전체 컴포넌트 레이아웃 조정
  - main 컴포넌트를 공통 레이아웃으로 빼냄
  - Timer가 완료되었을 때 메시지의 외곽선 제거 

<br>

## 기타 정보
리액트 훅 폼을 이해하느라구... 조금 오래걸렸습니다!
<br>