### PR TITLE
예매 티켓 내역 확인 페이지 구현

### DIFF
--- a/src/MyTicketRoute.tsx
+++ b/src/MyTicketRoute.tsx
@@ -1,0 +1,32 @@
+import { Outlet } from "react-router-dom";
+import MenuButton from "./components/MenuButton";
+import useAuthStore from "./stores/authStore";
+
+const myTicketMenu = ["예매완료", "취소내역"];
+
+export default function MyTicketRoute() {
+  const { userName } = useAuthStore((state) => ({ userName: state.userName }));
+
+  return (
+    <>
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold">어서오세요, {userName}님.</h1>
+        <span className="text-text-tertiary">예매내역을 클릭하면 상세정보를 확인할 수 있어요.</span>
+      </div>
+      <div className="mb-4 flex gap-4 border-b border-b-borders pb-4">
+        {myTicketMenu.map((menu) => (
+          <MenuButton
+            menu={menu}
+            key={menu}
+            onClick={() => {
+              console.log(menu);
+            }}
+          />
+        ))}
+      </div>
+      <div className="flex w-[1280px]">
+        <Outlet />
+      </div>
+    </>
+  );
+}

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -10,9 +10,12 @@ import Admin from "./pages/admin/Admin";
 import NotFound from "./pages/NotFound";
 import Registration from "./pages/admin/Registration";
 import { menu } from "./components/constants";
-import MyTickets from "./pages/MyTickets";
 import AuthRoute from "./AuthRoute";
 import AccountDeletion from "./pages/AccountDeletion";
+import MyTicketRoute from "./MyTicketRoute";
+import MyReservations from "./pages/MyReservations";
+import CancellationHistory from "./pages/CancellationHistory";
+import MyTeam from "./pages/MyTeam";
 
 export default function Router() {
   return (
@@ -34,7 +37,11 @@ export default function Router() {
           <Route path="profile" element={<AuthRoute />}>
             <Route path="user-info" element={<MyPage />} />
             <Route path="account-deletion" element={<AccountDeletion />} />
-            <Route path="my-tickets" element={<MyTickets />} />
+            <Route path="my-team" element={<MyTeam />} />
+            <Route path="my-tickets" element={<MyTicketRoute />}>
+              <Route path="my-reservations" element={<MyReservations />} />
+              <Route path="cancellation-history" element={<CancellationHistory />} />
+            </Route>
           </Route>
           <Route path="/admin" element={<Admin />} />
           <Route path="/admin/registration" element={<Registration />} />

--- a/src/components/Header/UserButton.tsx
+++ b/src/components/Header/UserButton.tsx
@@ -1,5 +1,5 @@
 import { FiUser, FiFileText, FiLogOut } from "react-icons/fi";
-import { LuUserCircle } from "react-icons/lu";
+import { LuUserCircle, LuTrophy } from "react-icons/lu";
 import useAuthStore from "../../stores/authStore";
 import usePopover from "../../hooks/usePopover";
 import MenuItem from "./MenuItem";
@@ -39,10 +39,11 @@ export default function UserButton() {
           <div className="border-t border-gray-200">
             <MenuItem to="/profile/user-info" icon={<FiUser className="mr-3" />} label="프로필" />
             <MenuItem
-              to="/profile/my-tickets"
+              to="/profile/my-tickets/my-reservations"
               icon={<FiFileText className="mr-3" />}
               label="예매한 티켓"
             />
+            <MenuItem to="/profile/my-team" icon={<LuTrophy className="mr-3" />} label="나의 팀" />
             <MenuItem
               onClick={handleLogout}
               icon={<FiLogOut className="mr-3" />}

--- a/src/components/MenuButton.tsx
+++ b/src/components/MenuButton.tsx
@@ -1,32 +1,45 @@
 import { CiCircleCheck, CiWarning, CiTrophy, CiCalendar, CiCircleInfo } from "react-icons/ci";
 import { LuHome } from "react-icons/lu";
+import { Link } from "react-router-dom";
 
 export default function MenuButton({ menu, onClick }: { menu: string; onClick: () => void }) {
   const getMenuIcon = (menu: string) => {
     switch (menu) {
       case "예매완료":
-        return <CiCircleCheck />;
-      case "예매취소":
-        return <CiWarning />;
-      case "나의 팀":
-        return <CiTrophy />;
+        return {
+          link: "/profile/my-tickets/my-reservations",
+          icon: <CiCircleCheck />,
+        };
+      case "취소내역":
+        return {
+          link: "/profile/my-tickets/cancellation-history",
+          icon: <CiWarning />,
+        };
       case "예매일정":
-        return <CiCalendar />;
+        return {
+          link: "",
+          icon: <CiCalendar />,
+        };
       case "홈구장 안내":
-        return <LuHome />;
+        return {
+          link: "",
+          icon: <LuHome />,
+        };
       case "예매정보":
-        return <CiCircleInfo />;
+        return {
+          link: "",
+          icon: <CiCircleInfo />,
+        };
     }
   };
 
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="button-hover flex items-center justify-center rounded-lg border bg-white px-[45px] py-[12px] text-[16px] text-black transition-colors duration-300"
+    <Link
+      to={getMenuIcon(menu)?.link as string}
+      className="button-hover flex w-[300px] items-center justify-center rounded-lg border bg-white px-[56px] py-[14px] text-[16px] text-black transition-colors duration-300"
     >
-      <span className="mr-2">{getMenuIcon(menu)}</span>
+      <span className="mr-2">{getMenuIcon(menu)?.icon}</span>
       {menu}
-    </button>
+    </Link>
   );
 }

--- a/src/pages/CancellationHistory.tsx
+++ b/src/pages/CancellationHistory.tsx
@@ -1,0 +1,3 @@
+export default function CancellationHistory() {
+  return <div>예매 취소 내역</div>;
+}

--- a/src/pages/InformationCard.tsx
+++ b/src/pages/InformationCard.tsx
@@ -1,0 +1,38 @@
+import { BsCalendar2EventFill } from "react-icons/bs";
+import { MdLocationOn } from "react-icons/md";
+interface InformationCardProp {
+  homeTeamName: string;
+  awayTeamName: string;
+  gameStartTime: string;
+  stadiumName: string;
+  reservationStatus?: boolean;
+}
+export default function InformationCard({
+  content: { homeTeamName, awayTeamName, gameStartTime, stadiumName, reservationStatus },
+}: {
+  content: InformationCardProp;
+}) {
+  return (
+    <div className="shadow-first w-[400px] rounded-[15px] border border-borders bg-foreground">
+      <div className="p-[20px]">
+        <div className="mb-2 border-b border-borders pb-2">
+          <span className="font-bold">
+            {homeTeamName} vs {awayTeamName}
+          </span>
+          <div className="mt-3 flex items-center gap-3">
+            <BsCalendar2EventFill className="size-4" />
+            <div className="flex flex-col text-xs">
+              <span className="">{gameStartTime}</span>
+              <span className="text-text-tertiary">{gameStartTime}</span>
+            </div>
+          </div>
+          <div className="mt-1 flex items-center gap-3">
+            <MdLocationOn className="size-4" />
+            <span className="text-xs">{stadiumName}</span>
+          </div>
+        </div>
+        {reservationStatus !== undefined && <span className="text-xs text-Accent">예매 완료</span>}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/MyReservations.tsx
+++ b/src/pages/MyReservations.tsx
@@ -1,0 +1,9 @@
+export default function MyReservations() {
+  return (
+    <>
+      <div className="flex flex-wrap gap-[40px]">
+        {/** InformationCard 혹은 정보 없음을 표시할 것. */}
+      </div>
+    </>
+  );
+}

--- a/src/pages/MyTeam.tsx
+++ b/src/pages/MyTeam.tsx
@@ -1,0 +1,3 @@
+export default function MyTeam() {
+  return <div>나의 팀</div>;
+}

--- a/src/pages/MyTickets.tsx
+++ b/src/pages/MyTickets.tsx
@@ -1,3 +1,0 @@
-export default function MyTickets() {
-  return <div>내티켓</div>;
-}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,6 +15,9 @@ export default {
         "focused-input-background": "rgba(219, 219, 219, 0.5)",
         "disabled-button": "rgb(238, 161, 169)",
       },
+      boxShadow: {
+        first: "0px 10px 20px rgba(0, 0, 0, 0.05)",
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## 이슈와 연결하기

Issue Number: #8

<br>

## 무엇이 추가 되었나요?

- 티켓 관련 라우팅을 중첩으로 구현했습니다.( MyTicketRoute > MyReservations(예매 내역), CancellationHistory(취소 내역))
  - 기존에 티켓 페이지였던 MyTickets 컴포넌를 삭제했습니다.
- 티켓 예매 페이지를 구현했습니다.
  - 예매한 티켓을 보여주는 InformationCard 컴포넌트를 구현했고, 나의 팀에도 사용할 예정입니다.
- UserButton에 나의 팀 항목을 추가했습니다.
- MenuButton에서 button 태그를 Link 컴포넌트로 변경했습니다.
<br>

## 기타 정보

<br>