### PR TITLE
AxiosInstance 및 Interceptor 설정 + 타이틀 및 favicon 설정

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/src/assets/logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Spoticks</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/common/utils/axiosInstance.ts
+++ b/src/common/utils/axiosInstance.ts
@@ -1,0 +1,7 @@
+import axios from "axios";
+
+const instance = axios.create({
+  baseURL: "http://spoticks.shop:8080/", // 서버 url
+  timeout: 3000, // 3000ms가 지나도 응답이 없으면 요청을 취소
+  headers: { "Content-Type": "application/json" }, // 클라에서 보내는 데이터의 형식
+});

--- a/src/common/utils/axiosInstance.ts
+++ b/src/common/utils/axiosInstance.ts
@@ -5,7 +5,7 @@ const AxiosInstance = axios.create({
   baseURL: "http://spoticks.shop:8080/", // 서버 url
   timeout: 3000, // 3000ms가 지나도 응답이 없으면 요청을 취소
   headers: { "Content-Type": "application/json" }, // 클라에서 보내는 데이터의 형식
-  withCredentials: true,
+  withCredentials: true, // 요청에 credential 정보를 담아서 보낼 지
 });
 
 AxiosInstance.interceptors.request.use((config) => {
@@ -13,7 +13,6 @@ AxiosInstance.interceptors.request.use((config) => {
   if (accessToken) {
     config.headers.Authorization = accessToken;
   }
-  console.log(config);
   return config;
 });
 

--- a/src/common/utils/axiosInstance.ts
+++ b/src/common/utils/axiosInstance.ts
@@ -1,7 +1,20 @@
+import useAuthStore from "@/common/stores/authStore";
 import axios from "axios";
 
-const instance = axios.create({
+const AxiosInstance = axios.create({
   baseURL: "http://spoticks.shop:8080/", // 서버 url
   timeout: 3000, // 3000ms가 지나도 응답이 없으면 요청을 취소
   headers: { "Content-Type": "application/json" }, // 클라에서 보내는 데이터의 형식
+  withCredentials: true,
 });
+
+AxiosInstance.interceptors.request.use((config) => {
+  const { accessToken } = useAuthStore.getState();
+  if (accessToken) {
+    config.headers.Authorization = accessToken;
+  }
+  console.log(config);
+  return config;
+});
+
+export default AxiosInstance;


### PR DESCRIPTION
## 이슈와 연결하기

Issue Number: #60

<br>

## 무엇이 추가 되었나요?
### 타이틀 및 favicon 설정
- 설정이 안되어있길래 빠르게 설정했습니다.
<img width="244" alt="스크린샷 2024-10-24 오전 11 44 28" src="https://github.com/user-attachments/assets/4d39ec73-2ca5-464a-b7ae-aa304cae37f0">

### AxiosInstance 및 Interceptor 설정
- AxiosInstance 설정
axios를 사용하는데 필요한 설정들 (일단 url)을 재사용하고 interceptor 사용하려고 instance를 사용했습니다.

```ts
const AxiosInstance = axios.create({
  baseURL: "http://spoticks.shop:8080/", // 서버 url
  timeout: 3000, // 3000ms가 지나도 응답이 없으면 요청을 취소
  headers: { "Content-Type": "application/json" }, // 클라에서 보내는 데이터의 형식
  withCredentials: true, // 요청에 credential 정보를 담아서 보낼 지
});
```
- baseURL: 서버 배포 주소
- timeout: 일단 3초로 했습니다.
- headers: 에는 다른 설정들은 건들지 않고 클라이언트에서 보내는 데이터의 형식만 일단 지정해뒀습니다.
- withCredentials: 권한이 필요한 곳에는 `accessToken`을 보내야 하니까 `true` 로 설정했습니다.

다음 예시처럼 사용하시면 됩니다.

```ts
const fetchGames = async () => {
  try {
    const response = await axiosInstance.get("/admin/games", {
      params: {
        page: 1,
      },
    });
    return response.data;
  } catch (error) {
    console.log(error);
  }
};
```


### Interceptor 설정
- 요청 보낼시 accessToken을 같이 보낼 수 있도록 Interceptor를 설정했습니다.
```ts
AxiosInstance.interceptors.request.use((config) => {
  const { accessToken } = useAuthStore.getState();
  if (accessToken) {
    config.headers.Authorization = accessToken;
  }
  return config;
});
```
`authStore` 에서 `accessToken` 가져오고 값이 `null`이 아니면 `Authorization` 에 보내는걸로 설정헸습니다.
<br>

## 기타 정보

<br>