### PR TITLE
로그인 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@tanstack/react-query-devtools": "^5.51.23",
         "axios": "^1.7.2",
         "json-server": "^1.0.0-beta.1",
+        "jwt-decode": "^4.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.52.1",
@@ -3779,6 +3780,14 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@tanstack/react-query-devtools": "^5.51.23",
     "axios": "^1.7.2",
     "json-server": "^1.0.0-beta.1",
+    "jwt-decode": "^4.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.52.1",

--- a/src/common/components/Layout/Header/UserButton/UserInfoPopup/index.tsx
+++ b/src/common/components/Layout/Header/UserButton/UserInfoPopup/index.tsx
@@ -1,8 +1,8 @@
-import isValidMemberId from "@/common/utils/isValidMemberId";
 import useAuthStore from "@/common/stores/authStore";
 import alertToast from "@/common/utils/alertToast";
 import PopupMenuList from "@/common/components/Layout/Header/UserButton/UserInfoPopup/PopupMenu/PopupMenuList";
 import getPopupMenuItems from "@/common/components/Layout/Header/UserButton/UserInfoPopup/PopupMenu/getPopupMenuItems";
+import useMemberInfo from "@/hooks/useMemberInfo";
 
 export default function UserInfoPopup({
   setIsPopoverOpen,
@@ -11,9 +11,8 @@ export default function UserInfoPopup({
   setIsPopoverOpen: React.Dispatch<React.SetStateAction<boolean>>;
   popoverRef: React.RefObject<HTMLDivElement>;
 }) {
-  const { memberName, memberId, logout } = useAuthStore((state) => ({
-    ...state,
-  }));
+  const memberInfo = useMemberInfo();
+  const { logout } = useAuthStore();
 
   function handleLogout() {
     logout();
@@ -21,9 +20,10 @@ export default function UserInfoPopup({
     alertToast("로그아웃 되었습니다!", "info");
   }
 
-  const menuItems = isValidMemberId(memberId)
-    ? getPopupMenuItems("user")
-    : getPopupMenuItems("admin");
+  const menuItems =
+    memberInfo?.authority === "ROLE_MEMBER"
+      ? getPopupMenuItems("user")
+      : getPopupMenuItems("admin");
   return (
     <div
       ref={popoverRef}
@@ -33,7 +33,7 @@ export default function UserInfoPopup({
         className="flex justify-center gap-1 p-2 text-[14px] font-semibold"
         onClick={(e) => e.stopPropagation()}
       >
-        <p className="truncate">{memberName}</p>
+        <p className="truncate">{memberInfo?.memberName}</p>
         <span className="font-normal"> 님</span>
       </div>
       <PopupMenuList items={menuItems} handleLogout={handleLogout} />

--- a/src/common/components/Layout/Header/index.tsx
+++ b/src/common/components/Layout/Header/index.tsx
@@ -2,20 +2,17 @@ import HeaderNav from "./HeaderNav";
 import AuthButtonGroup from "./AuthButtonGroup";
 import UserButton from "./UserButton";
 import AppLogo from "@/common/components/atoms/AppLogo";
-import useAuthStore from "@/common/stores/authStore";
-import isValidMemberId from "@/common/utils/isValidMemberId";
+import useMemberInfo from "@/hooks/useMemberInfo";
 
 export default function Header() {
-  const { accessToken, memberId } = useAuthStore((state) => ({
-    ...state,
-  }));
+  const memberInfo = useMemberInfo();
 
   return (
     <header className="sticky top-0 flex h-[80px] w-full justify-center border bg-foreground">
-      <div className="w-content-width flex items-center justify-between">
+      <div className="flex w-content-width items-center justify-between">
         <AppLogo />
-        {isValidMemberId(memberId) && <HeaderNav />}
-        {!accessToken ? <AuthButtonGroup /> : <UserButton />}
+        {memberInfo?.authority !== "ROLE_ADMIN" && <HeaderNav />}
+        {!memberInfo ? <AuthButtonGroup /> : <UserButton />}
       </div>
     </header>
   );

--- a/src/common/components/atoms/AppLogo.tsx
+++ b/src/common/components/atoms/AppLogo.tsx
@@ -1,14 +1,11 @@
 import { Link } from "react-router-dom";
 import Logo from "@/assets/logo.svg?react";
-import useAuthStore from "@/common/stores/authStore";
-import isValidMemberId from "@/common/utils/isValidMemberId";
+import useMemberInfo from "@/hooks/useMemberInfo";
 
 export default function AppLogo() {
-  const { memberId } = useAuthStore((state) => ({
-    ...state,
-  }));
+  const memberInfo = useMemberInfo();
 
-  const linkTo = isValidMemberId(memberId) ? "/" : "/admin";
+  const linkTo = memberInfo?.authority === "ROLE_ADMIN" ? "/admin" : "/";
 
   return (
     <Link to={linkTo}>

--- a/src/common/stores/authStore.tsx
+++ b/src/common/stores/authStore.tsx
@@ -2,31 +2,24 @@ import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 
 interface AuthStateStore {
-  memberId: number | null;
-  memberName: string | null;
-  phoneNumber: string | null;
   accessToken: string | null;
 }
 
 interface AuthStateActions {
-  login: (token: string, memberName: string, memberId: number) => void;
+  login: (token: string) => void;
   logout: () => void;
 }
 interface AuthStore extends AuthStateStore, AuthStateActions {}
 
 const initialState = {
   accessToken: null,
-  memberId: null,
-  memberName: null,
-  phoneNumber: null,
 };
 
 const useAuthStore = create<AuthStore>()(
   persist(
     (set) => ({
       ...initialState,
-      login: (accessToken: string, memberName: string, memberId: number) =>
-        set({ accessToken, memberName, memberId }),
+      login: (accessToken: string) => set({ accessToken }),
       logout: () => set(() => initialState),
     }),
     { name: "auth-storage", storage: createJSONStorage(() => localStorage) },

--- a/src/common/utils/isValidMemberId.ts
+++ b/src/common/utils/isValidMemberId.ts
@@ -1,4 +1,0 @@
-export default function isValidMemberId(memberId: number | null): memberId is number {
-  // 로그인이 되어있지 않을 경우 &&  && memberId가 3 보다 클 경우
-  return !memberId || memberId > 3 ? true : false;
-}

--- a/src/hooks/useMemberInfo.tsx
+++ b/src/hooks/useMemberInfo.tsx
@@ -1,0 +1,27 @@
+import useAuthStore from "@/common/stores/authStore";
+import { jwtDecode } from "jwt-decode";
+
+interface AuthorityType {
+  authority: string;
+}
+export interface DecodedTokenType {
+  sub: string; // 사용자 ID
+  memberName: string; // 회원이름
+  exp: number; // 토큰 만료 시간 (Unix timestamp)
+  iat: number; // 토큰 발급 시간 (Unix timestamp)
+  authorities: AuthorityType[]; // 사용자 권한
+  memberId: number; // 회원 고유 ID
+}
+export default function useMemberInfo() {
+  const { accessToken } = useAuthStore((state) => state);
+  if (typeof accessToken === "string") {
+    const {
+      memberId,
+      memberName,
+      authorities: [{ authority }],
+    } = jwtDecode<DecodedTokenType>(accessToken);
+    return { memberId, memberName, authority };
+  } else {
+    return null;
+  }
+}

--- a/src/pages/Login/api/useLoginMutation.ts
+++ b/src/pages/Login/api/useLoginMutation.ts
@@ -19,8 +19,8 @@ export default function useLoginMutation() {
       return await axiosInstance.post("auth/login", { userName, password });
     },
     onSuccess: (res) => {
-      const { token, memberName, memberId } = res.data;
-      useAuthStore.getState().login(token, memberName, memberId);
+      const { token } = res.data;
+      useAuthStore.getState().login(token);
       navigate("/");
       alertToast("로그인에 성공했어요!", "success");
     },


### PR DESCRIPTION
## 이슈와 연결하기

Issue Number: #74

<br>

## 무엇이 추가 되었나요?

### jwt-decode 패키지 설치
- 응답 형식이 바뀌어서 토큰을 디코딩하는 jwt-decode 라이브러리를 설치했습니다.

### `AuthStore` 로직 변경
```tsx
interface AuthStateActions {
  login: (token: string) => void;
  logout: () => void;
}
interface AuthStore extends AuthStateStore, AuthStateActions {}

const initialState = {
  accessToken: null,
};

const useAuthStore = create<AuthStore>()(
  persist(
    (set) => ({
      ...initialState,
      login: (accessToken: string) => set({ accessToken }),
      logout: () => set(() => initialState),
    }),
    { name: "auth-storage", storage: createJSONStorage(() => localStorage) },
	
```
- 토큰만 스토어(로컬 스토리지)에 저장하도록 바꿨습니다. 

### `useMemberInfo` 커스텀 훅 구현 
```tsx
interface AuthorityType {
  authority: string;
}
export interface DecodedTokenType {
  sub: string; // 사용자 ID
  memberName: string; // 회원이름
  exp: number; // 토큰 만료 시간 (Unix timestamp)
  iat: number; // 토큰 발급 시간 (Unix timestamp)
  authorities: AuthorityType[]; // 사용자 권한
  memberId: number; // 회원 고유 ID
}
export default function useMemberInfo() {
  const { accessToken } = useAuthStore((state) => state);
  if (typeof accessToken === "string") {
    const {
      memberId,
      memberName,
      authorities: [{ authority }],
    } = jwtDecode<DecodedTokenType>(accessToken);
    return { memberId, memberName, authority };
  } else {
    return null;
  }
}
```
- 토큰을 디코딩 해 페이로드를 반환하는 훅입니다. 만약 로그인 하지 않은 상태여서 `token` 이 `null` 이라면 `null`을 반환합니다. 

### `isValidMemberId` 삭제
기존에 회원의 일반/관리자 로 구분하던 `isValidMemberId` 함수를 삭제하고 구분하는 로직을 디코딩한 페이로드의 `authority` 로 바꿨습니다.

### 회원 구분에 따른 조건부 구현
```tsx
// Header.tsx
export default function Header() {
  const memberInfo = useMemberInfo();

  return (
    <header className="sticky top-0 flex h-[80px] w-full justify-center border bg-foreground">
      <div className="flex w-content-width items-center justify-between">
        <AppLogo />
        {memberInfo?.authority !== "ROLE_ADMIN" && <HeaderNav />}
        {!memberInfo ? <AuthButtonGroup /> : <UserButton />}
```
- 회원 권한에 따라 `HeaderNav` 를 관리자가 아닐 경우에만 조건부로 렌더링하고, 로그인이 되어있지 않으면 로그인 버튼을, 되어있다면 유저 버튼을 렌더링합니다.
```tsx
// UserInfoPopup.tsx
export default function UserInfoPopup({
  setIsPopoverOpen,
  popoverRef,
}: {
  setIsPopoverOpen: React.Dispatch<React.SetStateAction<boolean>>;
  popoverRef: React.RefObject<HTMLDivElement>;
}) {
  const memberInfo = useMemberInfo();
  const { logout } = useAuthStore();

  function handleLogout() {
    logout();
    setIsPopoverOpen(false);
    alertToast("로그아웃 되었습니다!", "info");
  }

  const menuItems =
    memberInfo?.authority === "ROLE_MEMBER"
      ? getPopupMenuItems("user")
      : getPopupMenuItems("admin");
  return (
    <div
      ref={popoverRef}
      className="absolute right-0 top-5 w-24 rounded-lg border border-borders bg-white shadow-lg"
    >
      <div
        className="flex justify-center gap-1 p-2 text-[14px] font-semibold"
        onClick={(e) => e.stopPropagation()}
      >
        <p className="truncate">{memberInfo?.memberName}</p>
```

- 유저 권한에 따라 팝업의 메뉴를 조건부로 렌더링합니다. 관리자일 경우 `getPopupMenuItems("admin")` 의 반환값을, 아닐 경우 `getPopupMenuItems("user")` 를 반환합니다.

```tsx
// AppLogo.tsx

export default function AppLogo() {
  const memberInfo = useMemberInfo();

  const linkTo = memberInfo?.authority === "ROLE_ADMIN" ? "/admin" : "/";

  return (
    <Link to={linkTo}>
```

- 관리자 계정일 경우 `/admin` 으로 보내고 아닐 경우 `/` 로 보냅니다. 
<br>

## 기타 정보

<br>