### PR TITLE
회원 탈퇴 로직 구현

### DIFF
--- a/src/common/validationSchema.ts
+++ b/src/common/validationSchema.ts
@@ -40,6 +40,8 @@ const signUpFormSchema = fullSchema.refine((data) => data.password === data.pass
   path: ["passwordConfirmation"],
 });
 
+const passwordSchema = z.object({ password: fullSchema.shape.password, reason: z.string() });
+
 const passwordSettingSchema = z
   .object({
     password: fullSchema.shape.password,
@@ -64,4 +66,10 @@ const phoneNumberSchema = fullSchema.pick({
   phoneNumber: true,
 });
 
-export { signUpFormSchema, passwordSettingSchema, loginFormSchema, phoneNumberSchema };
+export {
+  signUpFormSchema,
+  passwordSettingSchema,
+  loginFormSchema,
+  phoneNumberSchema,
+  passwordSchema,
+};

--- a/src/pages/AccountDeletion/api/useAccountDeletion.ts
+++ b/src/pages/AccountDeletion/api/useAccountDeletion.ts
@@ -1,0 +1,50 @@
+import useAuthStore from "@/common/stores/authStore";
+import { AccountDeletionFormType } from "@/common/types/formTypes";
+import alertToast from "@/common/utils/alertToast";
+import axiosInstance from "@/common/utils/axiosInstance";
+import { useMutation } from "@tanstack/react-query";
+import { AxiosError } from "axios";
+import { SubmitHandler } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
+
+export default function useAccountDeletion() {
+  const navigation = useNavigate();
+  const logout = useAuthStore((state) => state.logout);
+  const accountDeletionMutation = useMutation({
+    mutationFn: async ({ password }: { password: string }) => {
+      return await axiosInstance.delete("/members", {
+        data: { input: password },
+      });
+    },
+    onSuccess: () => {
+      logout();
+      navigation("/");
+      alertToast("성공적으로 탈퇴처리 되었습니다.", "success");
+    },
+    onError: (err: AxiosError) => {
+      if (err.response) {
+        const status = err.response?.status;
+        if (status >= 400 && status < 500) {
+          switch (status) {
+            case 401:
+              alertToast("비밀번호를 다시 확인해주세요!", "error");
+              break;
+            case 403:
+              alertToast("로그인이 만료되었습니다. 다시 로그인 해 주세요!", "error");
+          }
+        } else if (status >= 500) {
+          alertToast("서버에 문제가 발생했습니다! 잠시 후 다시 시도해주세요!", "error");
+        }
+      } else if (err.request) {
+        alertToast("서버로부터 응답이 없습니다!", "error");
+      } else {
+        alertToast("요청 중 문제가 발생했습니다!", "error");
+      }
+    },
+  });
+  const onSubmit: SubmitHandler<AccountDeletionFormType> = (data) => {
+    // 로그인 양식 제출 로직
+    accountDeletionMutation.mutate(data);
+  };
+  return onSubmit;
+}

--- a/src/pages/AccountDeletion/components/AccountDeletionForm/ReasonSelect/index.tsx
+++ b/src/pages/AccountDeletion/components/AccountDeletionForm/ReasonSelect/index.tsx
@@ -28,7 +28,7 @@ export default function ReasonSelect({ control }: { control: Control<AccountDele
               onClick={(e) => {
                 handleClickOptions(e);
                 if (isOpen) {
-                  field.onChange("");
+                  field.onChange(undefined);
                 }
               }}
               isOpen={isOpen}

--- a/src/pages/AccountDeletion/components/AccountDeletionForm/index.tsx
+++ b/src/pages/AccountDeletion/components/AccountDeletionForm/index.tsx
@@ -1,37 +1,30 @@
 import ReasonSelect from "@/pages/AccountDeletion/components/AccountDeletionForm/ReasonSelect";
 import { useForm } from "react-hook-form";
-import { useNavigate } from "react-router-dom";
 import { AccountDeletionFormType } from "@/common/types/formTypes";
 import FormInputField from "@/common/components/molecules/FormInputField";
-import validationRules from "@/common/validationRules";
-import useAuthStore from "@/common/stores/authStore";
 import BasicButton from "@/common/components/atoms/button/BasicButton";
 import { RED_BUTTON_STYLE_AUTH } from "@/common/buttonStyles";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { passwordSchema } from "@/common/validationSchema";
+import useAccountDeletion from "@/pages/AccountDeletion/api/useAccountDeletion";
 
 export default function AccountDeletionForm() {
-  const navigate = useNavigate();
-  const logout = useAuthStore((state) => state.logout);
-
   const {
     register,
     formState: { errors, isValid },
     handleSubmit,
     control,
-  } = useForm<AccountDeletionFormType>({ mode: "onTouched" });
-
-  const onSubmit = (data: AccountDeletionFormType) => {
-    console.log(data);
-    // 회원 탈퇴 처리 로직 추가
-    // 일단 logout으로 해둠
-    logout();
-    navigate("/");
-  };
+  } = useForm<AccountDeletionFormType>({
+    resolver: zodResolver(passwordSchema),
+    mode: "all",
+  });
+  const onSubmit = useAccountDeletion();
   return (
     <section className="w-60">
       <form onSubmit={handleSubmit(onSubmit)}>
         <FormInputField
           label="비밀번호"
-          register={register("password", validationRules.password)}
+          register={register("password")}
           error={errors.password}
           inputType="password"
         />

--- a/src/pages/MyPage/api/usePasswordResettingMutation.ts
+++ b/src/pages/MyPage/api/usePasswordResettingMutation.ts
@@ -4,10 +4,8 @@ import axiosInstance from "@/common/utils/axiosInstance";
 import { useMutation } from "@tanstack/react-query";
 import { AxiosError } from "axios";
 import { SubmitHandler, UseFormReset } from "react-hook-form";
-import { useNavigate } from "react-router-dom";
 
 export default function usePasswordResettingMutation(reset: UseFormReset<PasswordSettingFormType>) {
-  const navigation = useNavigate();
   const passwordResettingMutation = useMutation({
     mutationFn: async ({ password, newPassword }: PasswordResettingType) =>
       await axiosInstance.patch(`/members/password`, { password, newPassword }),

--- a/src/pages/MyPage/utils/formatPhoneNumber.ts
+++ b/src/pages/MyPage/utils/formatPhoneNumber.ts
@@ -1,6 +1,0 @@
-export default function formatPhoneNumber(phoneNumber: string) {
-  const matchedPhoneNumber = phoneNumber.match(/^(\d{3})(\d{4})(\d{4})$/);
-  return matchedPhoneNumber
-    ? `${matchedPhoneNumber[1]}-${matchedPhoneNumber[2]}-${matchedPhoneNumber[3]}`
-    : phoneNumber;
-}


### PR DESCRIPTION
## 이슈와 연결하기

Issue Number: #79

<br>

## 무엇이 추가 되었나요?
### `formatPhoneNumber` 함수 삭제
휴대폰 번호를 010-0000-0000 식으로 바꿔주는 함수였는데... 필요가 없어져서 삭제했습니다.

### 회원탈퇴를 위한 스키마 추가 
```ts
const passwordSchema = z.object({ password: fullSchema.shape.password, reason: z.string() });
```
비밀번호와 탈퇴 사유를 위한 스키마 입니다. 비밀번호 검증 로직은 회원 가입 스키마에서 가져왔고, 탈퇴 사유는 문자열로만 지정했습니다.

### 회원 탈퇴 구현
```tsx
// useAccountDeletion.ts
export default function useAccountDeletion() {
  const navigation = useNavigate();
  const logout = useAuthStore((state) => state.logout);
  const accountDeletionMutation = useMutation({
    mutationFn: async ({ password }: { password: string }) => {
      return await axiosInstance.delete("/members", {
        data: { input: password },
      });
    },
    onSuccess: () => {
      logout();
      navigation("/");
      alertToast("성공적으로 탈퇴처리 되었습니다.", "success");
    },
    onError: (err: AxiosError) => {
      if (err.response) {
        const status = err.response?.status;
        if (status >= 400 && status < 500) {
          switch (status) {
            case 401:
              alertToast("비밀번호를 다시 확인해주세요!", "error");
              break;
            case 403:
              alertToast("로그인이 만료되었습니다. 다시 로그인 해 주세요!", "error");
          }
        } else if (status >= 500) {
          alertToast("서버에 문제가 발생했습니다! 잠시 후 다시 시도해주세요!", "error");
        }
      } else if (err.request) {
        alertToast("서버로부터 응답이 없습니다!", "error");
      } else {
        alertToast("요청 중 문제가 발생했습니다!", "error");
      }
    },
  });
  const onSubmit: SubmitHandler<AccountDeletionFormType> = (data) => {
    // 로그인 양식 제출 로직
    accountDeletionMutation.mutate(data);
  };
  return onSubmit;
}
```

```tsx
// /AccountDeletionForm/index.tsx

...
  const {
    register,
    formState: { errors, isValid },
    handleSubmit,
    control,
  } = useForm<AccountDeletionFormType>({
    resolver: zodResolver(passwordSchema),
    mode: "all",
  });
  const onSubmit = useAccountDeletion();

...
  return (
    <section className="w-60">
      <form onSubmit={handleSubmit(onSubmit)}>
        <FormInputField
          label="비밀번호"
          register={register("password")}
          error={errors.password}
          inputType="password"
        />
```
회원 탈퇴를 구현했습니다. `useAccountDeletion` 훅이 `onSubmit` 을 반환하는데, 이를 회원 탈퇴 제출 함수로 사용했습니다.
성공하면 탈퇴 처리 후 홈으로 이동하며, 성공 토스트가 렌더링 됩니다.
실패하면 에러 코드에 따라 달라지며, 발생하는 에러 코드는 다음과 같습니다.
- 401에러(틀린 비밀번호 입력)
- 403에러(로그인 만료)
- 500번대(서버 문제)
- 응답이 없을 경우
<br>

## 기타 정보

<br>