### PR TITLE
♻️ refactor: matchList page 더보기버튼 수정중 #70

### DIFF
--- a/src/pages/MatchList/api/api.ts
+++ b/src/pages/MatchList/api/api.ts
@@ -5,15 +5,16 @@ import { getTeamId } from "@/common/utils/getTeamId";
 interface MatchApiParams {
   sport: string;
   selectedTeam: string;
+  page: number;
 }
 
-export function useMatchApi({ sport, selectedTeam }: MatchApiParams) {
+export function useMatchApi({ sport, selectedTeam, page }: MatchApiParams) {
   console.log(sport, selectedTeam);
   const selectedTeamId = getTeamId(sport, selectedTeam);
-  const url = selectedTeam === "전체 일정" ? `/admin/games` : `/teams/${selectedTeamId}/games`;
-  const params = selectedTeam === "전체 일정" ? { sport } : undefined;
+  const url = selectedTeam === "전체 일정" ? `/games/sports` : `/teams/${selectedTeamId}/games`;
+  const params = selectedTeam === "전체 일정" ? { sport, page } : undefined;
 
-  return useAxios<MatchType>(["matches", sport, selectedTeam], {
+  return useAxios<MatchType>(["matches", sport, selectedTeam, String(page)], {
     config: {
       url,
       method: "GET",

--- a/src/pages/MatchList/components/ReservationList.tsx
+++ b/src/pages/MatchList/components/ReservationList.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { ContentProps } from "@/common/types/type";
 import { TimeButton } from "@/common/components/atoms/button/TimeButton";
@@ -6,60 +6,73 @@ import TdComp from "./ui/TdComp";
 import BasicButton from "@/common/components/atoms/button/BasicButton";
 interface ReservationListProps {
   filterData: ContentProps[];
+  setCurrentPage: React.Dispatch<React.SetStateAction<number>>;
+  totalEl: number;
 }
-const ReservationList = ({ filterData }: ReservationListProps) => {
-  const [viewMatches, setViewMatches] = useState(5);
+const ReservationList = ({ filterData, setCurrentPage, totalEl }: ReservationListProps) => {
+  const [viewMatches, setViewMatches] = useState<ContentProps[]>([]);
+
+  useEffect(() => {
+    // setViewMatches((prevMatches) => [...prevMatches, ...filterData]);
+    setViewMatches(filterData);
+  }, [filterData]);
 
   const addViewClick = () => {
-    setViewMatches((prev) => prev + 5);
+    if (totalEl > viewMatches.length) {
+      setCurrentPage((prevPage) => prevPage + 1);
+    }
   };
 
   const columnName = ["Home", "Away", "장소", "날짜", ""];
 
   return (
     <div>
-      <table className="mx-[-10px] w-full border-separate border-spacing-x-[10px]">
-        <thead>
-          <tr>
-            {columnName.map((column) => (
-              <th
-                key={column}
-                className={`border px-4 py-2 text-text-primary opacity-50 ${column === "" ? "border-none bg-none" : "bg-foreground"}`}
-              >
-                {column}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {filterData.slice(0, viewMatches).map((match, index) => (
-            <tr
-              key={match.gameId}
-              className={`${index % 2 === 0 ? "bg-gray-100" : "bg-white"} text-[20px]`}
-            >
-              <TdComp>{match.homeTeam}</TdComp>
-              <TdComp>{match.awayTeam}</TdComp>
-              <TdComp>{match.stadium}</TdComp>
-              <TdComp>{match.gameStartTime.split("T")[0]}</TdComp>
-              <TdComp>
-                <Link
-                  to={`/reservation/${match.gameId}`}
-                  state={{ match: match }}
-                  className="cursor-pointer"
+      {filterData.length > 0 ? (
+        <table className="mx-[-10px] w-full border-separate border-spacing-x-[10px]">
+          <thead>
+            <tr>
+              {columnName.map((column) => (
+                <th
+                  key={column}
+                  className={`border px-4 py-2 text-text-primary opacity-50 ${column === "" ? "border-none bg-none" : "bg-foreground"}`}
                 >
-                  <TimeButton
-                    timeOnSale={match.timeOnSale}
-                    timeOffSale={match.timeOffSale}
-                    label="예매하기"
-                    className="w-26 flex items-center justify-center rounded-[10px] px-8 py-1 text-xs text-foreground"
-                  />
-                </Link>
-              </TdComp>
+                  {column}
+                </th>
+              ))}
             </tr>
-          ))}
-        </tbody>
-      </table>
-      {viewMatches < filterData.length && (
+          </thead>
+          <tbody>
+            {viewMatches.map((match, index) => (
+              <tr
+                key={match.gameId}
+                className={`${index % 2 === 0 ? "bg-gray-100" : "bg-white"} text-[20px]`}
+              >
+                <TdComp>{match.homeTeam}</TdComp>
+                <TdComp>{match.awayTeam}</TdComp>
+                <TdComp>{match.stadium}</TdComp>
+                <TdComp>{match.gameStartTime.split("T")[0]}</TdComp>
+                <TdComp>
+                  <Link
+                    to={`/reservation/${match.gameId}`}
+                    state={{ match: match }}
+                    className="cursor-pointer"
+                  >
+                    <TimeButton
+                      timeOnSale={match.timeOnSale}
+                      timeOffSale={match.timeOffSale}
+                      label="예매하기"
+                      className="w-26 flex items-center justify-center rounded-[10px] px-8 py-1 text-xs text-foreground"
+                    />
+                  </Link>
+                </TdComp>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <h1>해당 팀의 경기가 없습니다!</h1>
+      )}
+      {totalEl > viewMatches.length && (
         <div className="mt-4 flex justify-center">
           <BasicButton
             content="더보기"

--- a/src/pages/MatchList/components/ui/MatchDetailMenu.tsx
+++ b/src/pages/MatchList/components/ui/MatchDetailMenu.tsx
@@ -10,9 +10,17 @@ interface DetailProps {
   selectedTeam: string;
   filterData: ContentProps[];
   sport: string;
+  setCurrentPage: React.Dispatch<React.SetStateAction<number>>;
+  totalEl: number;
 }
 
-export default function MatchDetailMenu({ selectedTeam, filterData, sport }: DetailProps) {
+export default function MatchDetailMenu({
+  selectedTeam,
+  filterData,
+  sport,
+  setCurrentPage,
+  totalEl,
+}: DetailProps) {
   //예매내역, 홈구장안내, 예매설명 메뉴 선택
   const [selectedMenu, setSelectedMenu] = useState("예매 일정");
   const handleMenuClick = (menu: string) => {
@@ -22,13 +30,25 @@ export default function MatchDetailMenu({ selectedTeam, filterData, sport }: Det
   const MenuList = () => {
     switch (selectedMenu) {
       case "예매 일정":
-        return <ReservationList filterData={filterData} />;
+        return (
+          <ReservationList
+            filterData={filterData}
+            setCurrentPage={setCurrentPage}
+            totalEl={totalEl}
+          />
+        );
       case "홈구장 안내":
         return <HomeInfo />;
       case "예매정보":
         return <ReserveInfo />;
       default:
-        return <ReservationList filterData={filterData} />;
+        return (
+          <ReservationList
+            filterData={filterData}
+            setCurrentPage={setCurrentPage}
+            totalEl={totalEl}
+          />
+        );
     }
   };
 

--- a/src/pages/MatchList/index.tsx
+++ b/src/pages/MatchList/index.tsx
@@ -18,47 +18,58 @@ export default function MatchList({ sport }: MatchListProps) {
   // Tab에서 선택된 team
   const [selectedTeam, setSelectedTeam] = useState("");
   const [filterData, setFilterData] = useState<ContentProps[]>([]);
-
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalEl, setTotatlEl] = useState(0);
+  console.log("filterData :", filterData);
+  console.log("currentPage :", currentPage);
   const {
     data: matchData = { content: [], pageInfo: {} as PageInfoProps },
     isLoading,
     error,
-  } = useMatchApi({ sport, selectedTeam: selectedTeam || "전체 일정" });
+  } = useMatchApi({ sport, selectedTeam: selectedTeam || "전체 일정", page: currentPage });
 
   useEffect(() => {
     setSelectedTeam("");
     navigate(`/match-list/${sport}`);
   }, [sport]);
-
+  console.log("data :", matchData);
   useEffect(() => {
-    if (selectedTeam === "전체 일정") {
-      setFilterData(matchData.content);
-      navigate(`/match-list/${sport}/allSche`);
-    } else {
-      const selectedTeamId = getTeamId(sport, selectedTeam);
-      if (selectedTeamId) {
-        setFilterData(
-          matchData.content.filter(
+    if (selectedTeam) {
+      if (selectedTeam === "전체 일정") {
+        setFilterData([]);
+        setCurrentPage(1);
+        setTotatlEl(matchData.pageInfo.totalElements);
+        setFilterData(matchData.content);
+        navigate(`/match-list/${sport}/allSche`);
+      } else {
+        const selectedTeamId = getTeamId(sport, selectedTeam);
+        if (selectedTeamId) {
+          const filteredMatches = matchData.content.filter(
             (game) => game.homeTeam === selectedTeam || game.awayTeam === selectedTeam,
-          ),
-        );
+          );
+          setFilterData(filteredMatches);
+        }
       }
     }
-  }, [matchData, selectedTeam, sport]);
+  }, [matchData, navigate, selectedTeam, sport]);
 
   if (isLoading) return <Loading />;
   if (error) return <Error />;
 
   return (
-    <div className="w-content-width flex flex-row pt-10">
-      {matchData.content.length > 0 && (
+    <div className="flex w-content-width flex-row pt-10">
+      {(matchData.content.length > 0 || (selectedTeam && filterData.length === 0)) && (
         <MatchListTab sport={sport} setSelectedTeam={setSelectedTeam} />
       )}
       <div className="flex w-full pl-[30px]">
-        {selectedTeam === "전체 일정" ? (
-          <MatchDetailMenu selectedTeam={selectedTeam} filterData={filterData} sport={sport} />
-        ) : selectedTeam ? (
-          <MatchDetailMenu selectedTeam={selectedTeam} filterData={filterData} sport={sport} />
+        {selectedTeam === "전체 일정" || selectedTeam ? (
+          <MatchDetailMenu
+            selectedTeam={selectedTeam}
+            filterData={filterData}
+            sport={sport}
+            setCurrentPage={setCurrentPage}
+            totalEl={totalEl}
+          />
         ) : (
           <Main sceduleLen={matchData.content.length} sport={sport} />
         )}


### PR DESCRIPTION
## 이슈와 연결하기 

Issue Number: #70 

<br> 

## 무엇이 추가 되었나요?

- MatchList의 api 경로가 변경되었습니다.
- 더보기 버튼을 수정중입니다.
  - totalEl과 비교하여 더보기버튼을 누르면 누적으로 보여지도록 해야하는데 페이지가 넘어가버리는 현상이 발생하여 코드변경중입니다
```tsx
const addViewClick = () => {
    setViewMatches((prev) => prev + 5);
    if (totalEl > viewMatches.length) {
      setCurrentPage((prevPage) => prevPage + 1);
    }
  };
```
  - 그래서 props로 setCurrentPage와 totalEl을 추가로 넘겨주고 있습니다.
```tsx
 <ReservationList
            filterData={filterData}
            setCurrentPage={setCurrentPage}
            totalEl={totalEl}
          />
```

 <br> 

## 기타 정보 

- 코드가 모두 수정되면 console.log()는 없어질 예정입니다.
<br>