### PR TITLE
예매 내역 페이지 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "react-error-boundary": "^4.1.2",
         "react-hook-form": "^7.52.1",
         "react-icons": "^5.2.1",
-        "react-intersection-observer": "^9.13.0",
+        "react-intersection-observer": "^9.13.1",
         "react-modal": "^3.16.1",
         "react-router-dom": "^6.25.1",
         "sweetalert2": "^11.12.4",
@@ -4655,9 +4655,9 @@
       }
     },
     "node_modules/react-intersection-observer": {
-      "version": "9.13.0",
-      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.13.0.tgz",
-      "integrity": "sha512-y0UvBfjDiXqC8h0EWccyaj4dVBWMxgEx0t5RGNzQsvkfvZwugnKwxpu70StY4ivzYuMajavwUDjH4LJyIki9Lw==",
+      "version": "9.13.1",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.13.1.tgz",
+      "integrity": "sha512-tSzDaTy0qwNPLJHg8XZhlyHTgGW6drFKTtvjdL+p6um12rcnp8Z5XstE+QNBJ7c64n5o0Lj4ilUleA41bmDoMw==",
       "peerDependencies": {
         "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "react-error-boundary": "^4.1.2",
     "react-hook-form": "^7.52.1",
     "react-icons": "^5.2.1",
-    "react-intersection-observer": "^9.13.0",
+    "react-intersection-observer": "^9.13.1",
     "react-modal": "^3.16.1",
     "react-router-dom": "^6.25.1",
     "sweetalert2": "^11.12.4",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ const queryClient = new QueryClient({
         if (status === 403) {
           useAuthStore.getState().logout();
           alertToast("로그인이 만료되었습니다. 다시 로그인 해주세요!", "info");
+          queryClient.clear();
         }
       }
     },
@@ -26,6 +27,7 @@ const queryClient = new QueryClient({
         if (status === 403) {
           useAuthStore.getState().logout();
           alertToast("로그인이 만료되었습니다. 다시 로그인 해주세요!", "info");
+          queryClient.clear();
         }
       }
     },

--- a/src/assets/calendar-delete.svg
+++ b/src/assets/calendar-delete.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="400px" height="400px" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6.103 24.423H57.232" stroke="#000000" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M51.905 13.061H11.429C8.48753 13.061 6.103 15.4456 6.103 18.387V47.501C6.103 50.4425 8.48753 52.827 11.429 52.827H51.905C54.8465 52.827 57.231 50.4425 57.231 47.501V18.387C57.231 15.4456 54.8465 13.061 51.905 13.061Z" stroke="#000000" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M20.306 10.22V15.901" stroke="#426AB2" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M43.029 10.22V15.901" stroke="#426AB2" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M25.662 32.4351L37.706 44.5431" stroke="#426AB2" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M37.706 32.4351L25.662 44.5431" stroke="#426AB2" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/common/buttonStyles.ts
+++ b/src/common/buttonStyles.ts
@@ -5,4 +5,12 @@ const RED_BUTTON_STYLE_AUTH = "mt-4 " + BASIC_RED_BUTTON_STYLE;
 
 const RED_TEXT_STYLE_AUTH = "text-Accent hover:text-button-hovered";
 
-export { BASIC_RED_BUTTON_STYLE, RED_BUTTON_STYLE_AUTH, RED_TEXT_STYLE_AUTH };
+const BASIC_GREY_BUTTON_STYLE =
+  "px-3 py-2 w-full rounded-[10px] bg-borders text-[16px] text-center hover:bg-text-tertiary disabled:cursor-not-allowed disabled:bg-text-tertiary";
+
+export {
+  BASIC_RED_BUTTON_STYLE,
+  RED_BUTTON_STYLE_AUTH,
+  RED_TEXT_STYLE_AUTH,
+  BASIC_GREY_BUTTON_STYLE,
+};

--- a/src/common/components/AuthLayout/hooks/useContent.ts
+++ b/src/common/components/AuthLayout/hooks/useContent.ts
@@ -3,7 +3,6 @@ import { useLocation } from "react-router-dom";
 
 export default function useContent() {
   const location = useLocation();
-  console.log(location.pathname);
   const { heading, paragraph } = getContent(location.pathname);
 
   return { heading, paragraph };

--- a/src/common/components/AuthLayout/hooks/useContent.ts
+++ b/src/common/components/AuthLayout/hooks/useContent.ts
@@ -3,6 +3,7 @@ import { useLocation } from "react-router-dom";
 
 export default function useContent() {
   const location = useLocation();
+  console.log(location.pathname);
   const { heading, paragraph } = getContent(location.pathname);
 
   return { heading, paragraph };

--- a/src/common/components/AuthLayout/utils/getContent.ts
+++ b/src/common/components/AuthLayout/utils/getContent.ts
@@ -3,28 +3,34 @@ export default function getContent(pathname: string) {
     heading: "",
     paragraph: "",
   };
-  switch (pathname) {
-    case "/profile/user-info": {
+
+  switch (true) {
+    case pathname === "/profile/user-info":
       content.heading = "회원 정보";
       content.paragraph = "회원 정보를 확인하고 수정하세요.";
       break;
-    }
-    case "/profile/account-deletion": {
+
+    case pathname === "/profile/account-deletion":
       content.heading = "회원 탈퇴";
       content.paragraph = "회원 탈퇴를 신청하기 전에 안내사항을 확인해주세요.";
       break;
-    }
-    case "/profile/my-tickets/my-reservations":
-    case "/profile/my-tickets/cancellation-history": {
+
+    case pathname.startsWith("/profile/my-tickets/my-reservations"):
+    case pathname.startsWith("/profile/my-tickets/cancellation-history"):
       content.heading = "예매/취소 내역";
       content.paragraph = "내역을 클릭하면 상세정보를 확인할 수 있어요.";
       break;
-    }
-    case "/profile/my-team": {
+
+    case pathname === "/profile/my-team":
       content.heading = "My Team";
       content.paragraph = "회원님께서 관심있는 팀을 확인해보세요!";
       break;
-    }
+
+    default:
+      content.heading = "알 수 없는 페이지";
+      content.paragraph = "해당 페이지를 찾을 수 없습니다.";
+      break;
   }
+
   return content;
 }

--- a/src/common/components/Layout/index.tsx
+++ b/src/common/components/Layout/index.tsx
@@ -12,7 +12,10 @@ export default function Layout() {
   return (
     <div className="flex min-h-screen flex-col items-center">
       <Header />
-      <div className="flex w-content-width flex-1 flex-col items-center pt-[80px]">
+      <div
+        id="swal-relative"
+        className="relative flex w-content-width flex-1 flex-col items-center pt-[80px]"
+      >
         <main className="flex w-full flex-1 flex-col">
           <ErrorBoundary
             FallbackComponent={ErrorPage}

--- a/src/common/components/Layout/index.tsx
+++ b/src/common/components/Layout/index.tsx
@@ -12,10 +12,7 @@ export default function Layout() {
   return (
     <div className="flex min-h-screen flex-col items-center">
       <Header />
-      <div
-        id="swal-relative"
-        className="relative flex w-content-width flex-1 flex-col items-center pt-[80px]"
-      >
+      <div className="relative mb-20 flex w-content-width flex-1 flex-col items-center pt-[80px]">
         <main className="flex w-full flex-1 flex-col">
           <ErrorBoundary
             FallbackComponent={ErrorPage}

--- a/src/common/components/atoms/DefaultCard.tsx
+++ b/src/common/components/atoms/DefaultCard.tsx
@@ -1,6 +1,6 @@
 export default function DefaultCard({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex-1 rounded-[15px] border border-borders bg-foreground p-3 shadow-first">
+    <div className="flex-1 rounded-[10px] border border-borders bg-foreground p-3 shadow-first">
       {children}
     </div>
   );

--- a/src/common/components/organisms/DetailedTicket.tsx
+++ b/src/common/components/organisms/DetailedTicket.tsx
@@ -1,37 +1,39 @@
-import { MatchDataProps } from "@/common/types/type";
+import { InformationCardProp } from "@/common/types/type";
 import Barcode from "@/assets/Barcode.svg?react";
 import extractDateAndTime from "@/common/utils/extractDateAndTime";
+import { SeatType } from "@/pages/MyTicket/api/useReservationDetails";
 
 interface DetailedTicketProps {
-  data: MatchDataProps;
+  game: InformationCardProp;
   isReservationComplete?: boolean;
-  mySeats?: string[];
-  totalPay?: string;
+  mySeats?: SeatType[];
+  totalPay?: number;
 }
 
 export default function DetailedTicket({
-  data,
+  game,
   isReservationComplete,
   mySeats,
   totalPay,
 }: DetailedTicketProps) {
-  const { date, hours, minutes } = extractDateAndTime(data.gameStartTime);
+  const { date, hours, minutes } = extractDateAndTime(game.gameStartTime);
   return (
     <div
       className={`mb-6 flex w-full flex-col items-start rounded-[10px] ${isReservationComplete === true || isReservationComplete === undefined ? "bg-Accent" : "bg-borders"} px-5 py-6 drop-shadow-first`}
     >
-      <h2 className="mb-4 w-full border-b-2 border-b-text-secondary pb-2 text-[20px] font-bold">
-        {data.homeTeamName} vs {data.awayTeamName}
-      </h2>
+      <p className="w-full text-[20px] font-bold">{game.homeTeamName}</p>
+      <p className="w-full text-[20px] font-bold">vs</p>
+      <p className="w-full text-[20px] font-bold">{game.awayTeamName}</p>
+      <hr className="border-1 my-1 w-full border-text-secondary" />
       <div className="mb-2 flex flex-col">
-        <div className="text-[14px] text-text-secondary">{data.stadiumName}</div>
+        <div className="text-[14px] text-text-secondary">{game.stadiumName}</div>
         <div className="text-[14px]">
           {date} {hours}:{minutes}
         </div>
       </div>
-      {totalPay && mySeats ? (
-        <div className="flex w-full justify-end font-bold">
-          총 {mySeats.length} 매 {totalPay}원
+      {!isReservationComplete ? (
+        <div className="w-full font-bold">
+          총 {mySeats?.length} 매 {totalPay}원
         </div>
       ) : (
         <Barcode className="h-[30px]" />

--- a/src/common/types/type.ts
+++ b/src/common/types/type.ts
@@ -42,8 +42,11 @@ export interface InformationCardProp {
   gameStartTime: string;
   stadiumName: string;
   reservationStatus?: boolean;
-  id: number;
+  latitude: number;
+  longitude: number;
 }
+
+export type GameHistoryType = { reservationId: number; game: InformationCardProp }[];
 
 export interface Seat {
   id: number;

--- a/src/common/utils/basicToast.ts
+++ b/src/common/utils/basicToast.ts
@@ -3,11 +3,14 @@ import withReactContent from "sweetalert2-react-content";
 
 const MySwal = withReactContent(Swal);
 
+const main = document.getElementById("swal-relative");
+
 const basicToast = MySwal.mixin({
   toast: true,
   position: "top-end",
   showConfirmButton: false,
   timer: 3000,
+  target: main,
   timerProgressBar: true,
   didOpen: (toast) => {
     toast.onmouseenter = Swal.stopTimer;
@@ -16,7 +19,7 @@ const basicToast = MySwal.mixin({
   },
   width: "auto",
   customClass: {
-    container: "pt-[80px]",
+    container: "absolute p-0",
     popup: "rounded-[10px] text-xs",
   },
 });

--- a/src/common/utils/basicToast.ts
+++ b/src/common/utils/basicToast.ts
@@ -17,7 +17,7 @@ const basicToast = MySwal.mixin({
   },
   width: "auto",
   customClass: {
-    container: "absolute p-0",
+    container: "absolute pt-0",
     popup: "rounded-[10px] text-xs",
   },
 });

--- a/src/common/utils/basicToast.ts
+++ b/src/common/utils/basicToast.ts
@@ -3,14 +3,12 @@ import withReactContent from "sweetalert2-react-content";
 
 const MySwal = withReactContent(Swal);
 
-const main = document.getElementById("swal-relative");
-
 const basicToast = MySwal.mixin({
   toast: true,
   position: "top-end",
   showConfirmButton: false,
   timer: 3000,
-  target: main,
+  target: "main",
   timerProgressBar: true,
   didOpen: (toast) => {
     toast.onmouseenter = Swal.stopTimer;

--- a/src/pages/MyTicket/api/useMyTicketHistory.ts
+++ b/src/pages/MyTicket/api/useMyTicketHistory.ts
@@ -1,16 +1,16 @@
-import { InformationCardProp } from "@/common/types/type";
+import { GameHistoryType } from "@/common/types/type";
 import axiosInstance from "@/common/utils/axiosInstance";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { useLocation } from "react-router-dom";
 
 export default function useMyTicketHistory() {
   const location = useLocation().pathname;
-  const param = location === "/profile/my-tickets/my-reservations" ? "COMPLETE" : "CANCEL";
-  const { data } = useSuspenseQuery<InformationCardProp[]>({
+  const param = location.includes("/profile/my-tickets/my-reservations") ? "COMPLETE" : "CANCEL";
+  const { data } = useSuspenseQuery<GameHistoryType>({
     queryKey: ["myReservations", param],
     queryFn: async () => {
       const res = await axiosInstance.get(`reservation?status=${param}&page=1`);
-      return res.data;
+      return res.data.content;
     },
   });
   return {

--- a/src/pages/MyTicket/api/useMyTicketHistory.ts
+++ b/src/pages/MyTicket/api/useMyTicketHistory.ts
@@ -14,7 +14,6 @@ export default function useMyTicketHistory() {
       return res.data;
     },
     initialPageParam: 1,
-    maxPages: 3,
     getNextPageParam: (lastPage) => {
       return lastPage.pageInfo.totalPages > lastPage.pageInfo.page
         ? lastPage.pageInfo.page + 1

--- a/src/pages/MyTicket/api/useMyTicketHistory.ts
+++ b/src/pages/MyTicket/api/useMyTicketHistory.ts
@@ -6,7 +6,7 @@ import { useLocation } from "react-router-dom";
 export default function useMyTicketHistory() {
   const location = useLocation().pathname;
   const param = location === "/profile/my-tickets/my-reservations" ? "COMPLETE" : "CANCEL";
-  const { data = [] } = useSuspenseQuery<InformationCardProp[]>({
+  const { data } = useSuspenseQuery<InformationCardProp[]>({
     queryKey: ["myReservations", param],
     queryFn: async () => {
       const res = await axiosInstance.get(`reservation?status=${param}&page=1`);

--- a/src/pages/MyTicket/api/useMyTicketHistory.ts
+++ b/src/pages/MyTicket/api/useMyTicketHistory.ts
@@ -1,13 +1,13 @@
 import { GameHistoryType, PageInfoProps } from "@/common/types/type";
 import axiosInstance from "@/common/utils/axiosInstance";
-import { useInfiniteQuery } from "@tanstack/react-query";
+import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
 import { useLocation } from "react-router-dom";
 
 export default function useMyTicketHistory() {
   const location = useLocation().pathname;
   const param = location.includes("/profile/my-tickets/my-reservations") ? "COMPLETE" : "CANCEL";
 
-  return useInfiniteQuery<{ content: GameHistoryType; pageInfo: PageInfoProps }>({
+  return useSuspenseInfiniteQuery<{ content: GameHistoryType; pageInfo: PageInfoProps }>({
     queryKey: ["myReservations", param],
     queryFn: async ({ pageParam }) => {
       const res = await axiosInstance.get(`reservation?status=${param}&page=${pageParam}`);
@@ -16,7 +16,6 @@ export default function useMyTicketHistory() {
     initialPageParam: 1,
     maxPages: 3,
     getNextPageParam: (lastPage) => {
-      console.log(lastPage.pageInfo.page);
       return lastPage.pageInfo.totalPages > lastPage.pageInfo.page
         ? lastPage.pageInfo.page + 1
         : null;

--- a/src/pages/MyTicket/api/useMyTicketHistory.ts
+++ b/src/pages/MyTicket/api/useMyTicketHistory.ts
@@ -1,19 +1,19 @@
-import { GameHistoryType } from "@/common/types/type";
+import { GameHistoryType, PageInfoProps } from "@/common/types/type";
 import axiosInstance from "@/common/utils/axiosInstance";
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 import { useLocation } from "react-router-dom";
 
 export default function useMyTicketHistory() {
   const location = useLocation().pathname;
   const param = location.includes("/profile/my-tickets/my-reservations") ? "COMPLETE" : "CANCEL";
-  const { data } = useSuspenseQuery<GameHistoryType>({
+
+  return useInfiniteQuery<{ content: GameHistoryType; pageInfo: PageInfoProps }>({
     queryKey: ["myReservations", param],
     queryFn: async () => {
       const res = await axiosInstance.get(`reservation?status=${param}&page=1`);
-      return res.data.content;
+      return res.data;
     },
+    initialPageParam: 1,
+    getNextPageParam: (lastPage) => lastPage.pageInfo.page + 1,
   });
-  return {
-    data,
-  };
 }

--- a/src/pages/MyTicket/api/useMyTicketHistory.ts
+++ b/src/pages/MyTicket/api/useMyTicketHistory.ts
@@ -9,11 +9,17 @@ export default function useMyTicketHistory() {
 
   return useInfiniteQuery<{ content: GameHistoryType; pageInfo: PageInfoProps }>({
     queryKey: ["myReservations", param],
-    queryFn: async () => {
-      const res = await axiosInstance.get(`reservation?status=${param}&page=1`);
+    queryFn: async ({ pageParam }) => {
+      const res = await axiosInstance.get(`reservation?status=${param}&page=${pageParam}`);
       return res.data;
     },
     initialPageParam: 1,
-    getNextPageParam: (lastPage) => lastPage.pageInfo.page + 1,
+    maxPages: 3,
+    getNextPageParam: (lastPage) => {
+      console.log(lastPage.pageInfo.page);
+      return lastPage.pageInfo.totalPages > lastPage.pageInfo.page
+        ? lastPage.pageInfo.page + 1
+        : null;
+    },
   });
 }

--- a/src/pages/MyTicket/api/useReservationDetails.ts
+++ b/src/pages/MyTicket/api/useReservationDetails.ts
@@ -1,38 +1,31 @@
-import { useQuery } from "@tanstack/react-query";
-import axios from "axios";
+import { InformationCardProp } from "@/common/types/type";
+import axiosInstance from "@/common/utils/axiosInstance";
+import { useSuspenseQuery } from "@tanstack/react-query";
 
-interface Seat {
+export interface SeatType {
   seatPosition: string;
-  seatRow: string;
-  seatNumber: string;
+  seatRow: number;
+  seatNum: number;
 }
 
 interface GameReservation {
-  homeTeamName: string;
-  awayTeamName: string;
-  gameStartTime: string;
-  stadiumName: string;
-  reservationStatus: string;
-  totalPrice: string;
-  createDate: string;
+  createdAt: string;
   memberName: string;
-  seat: Seat[];
-  gameId: number;
-  id: string;
-  sportName: string;
-  timeOffSale: string;
-  timeOnSale: string;
+  reservationStatus: "CANCELED" | "COMPLETED";
+  seats: SeatType[];
+  totalPrice: number;
+  game: InformationCardProp;
 }
 
 const fetchReservationDetails = async (reservationId: number) => {
-  const { data } = await axios.get(`http://localhost:3000/reservation/${reservationId}`);
+  console.log(reservationId);
+  const { data } = await axiosInstance.get(`/reservation/${reservationId}`);
   return data;
 };
 
-export default function useReservationDetails(reservationId: number, isOpen: boolean) {
-  return useQuery<GameReservation>({
+export default function useReservationDetails(reservationId: number) {
+  return useSuspenseQuery<GameReservation>({
     queryKey: ["reservationDetail", reservationId],
     queryFn: () => fetchReservationDetails(reservationId),
-    enabled: isOpen,
   });
 }

--- a/src/pages/MyTicket/api/useReservationDetails.ts
+++ b/src/pages/MyTicket/api/useReservationDetails.ts
@@ -18,14 +18,28 @@ interface GameReservation {
 }
 
 const fetchReservationDetails = async (reservationId: number) => {
-  console.log(reservationId);
   const { data } = await axiosInstance.get(`/reservation/${reservationId}`);
   return data;
 };
 
+function getReservationStatus(reservationStatus: string) {
+  return reservationStatus === "COMPLETED" ? true : false;
+}
+
+function isGameDatePast(gameStartTime: string) {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const gameDate = new Date(gameStartTime);
+  gameDate.setHours(0, 0, 0, 0);
+  // 게임 시작일 <= 오늘
+  return gameDate <= today;
+}
 export default function useReservationDetails(reservationId: number) {
-  return useSuspenseQuery<GameReservation>({
+  const { data, isSuccess } = useSuspenseQuery<GameReservation>({
     queryKey: ["reservationDetail", reservationId],
     queryFn: () => fetchReservationDetails(reservationId),
   });
+  const isReservationComplete = getReservationStatus(data.reservationStatus);
+  const gamePassed = isGameDatePast(data.game.gameStartTime);
+  return { data, isSuccess, isReservationComplete, gamePassed };
 }

--- a/src/pages/MyTicket/api/useTicketCancellationMutation.ts
+++ b/src/pages/MyTicket/api/useTicketCancellationMutation.ts
@@ -1,9 +1,11 @@
 import alertToast from "@/common/utils/alertToast";
 import axiosInstance from "@/common/utils/axiosInstance";
 import { useQueryClient, useMutation } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
 
 export default function useTicketCancellationMutation(onClose: () => void, reservationId: number) {
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
   const mutation = useMutation({
     mutationFn: async (reservationId: number) => {
       await axiosInstance.delete(`reservation/${reservationId}`);
@@ -11,10 +13,10 @@ export default function useTicketCancellationMutation(onClose: () => void, reser
     onSuccess: () => {
       alertToast("예약을 취소했습니다!", "success");
       queryClient.invalidateQueries({ queryKey: ["myReservations"] });
+      navigate("/profile/my-tickets/my-reservations");
       onClose();
     },
     onError: (error) => {
-      console.log(error);
       alertToast("취소에 실패했습니다!", "error");
     },
   });

--- a/src/pages/MyTicket/api/useTicketCancellationMutation.ts
+++ b/src/pages/MyTicket/api/useTicketCancellationMutation.ts
@@ -1,21 +1,21 @@
+import alertToast from "@/common/utils/alertToast";
+import axiosInstance from "@/common/utils/axiosInstance";
 import { useQueryClient, useMutation } from "@tanstack/react-query";
-import axios from "axios";
 
 export default function useTicketCancellationMutation(onClose: () => void, reservationId: number) {
   const queryClient = useQueryClient();
   const mutation = useMutation({
-    mutationFn: (reservationId: number) => {
-      const request1 = axios.delete(`http://localhost:3000/reservation/${reservationId}`);
-      const request2 = axios.delete(`http://localhost:3000/reservations/${reservationId}`);
-      return Promise.all([request1, request2]);
+    mutationFn: async (reservationId: number) => {
+      await axiosInstance.delete(`reservation/${reservationId}`);
     },
     onSuccess: () => {
-      console.log("성공함!");
+      alertToast("예약을 취소했습니다!", "success");
       queryClient.invalidateQueries({ queryKey: ["myReservations"] });
       onClose();
     },
     onError: (error) => {
-      console.log(error, "때문에 실패함");
+      console.log(error);
+      alertToast("취소에 실패했습니다!", "error");
     },
   });
   function onCancelConfirmClick() {

--- a/src/pages/MyTicket/components/InformationCard/index.tsx
+++ b/src/pages/MyTicket/components/InformationCard/index.tsx
@@ -8,21 +8,24 @@ import { MdLocationOn } from "react-icons/md";
 import { useNavigate } from "react-router-dom";
 
 export default function InformationCard({
-  content: { homeTeamName, awayTeamName, gameStartTime, stadiumName, reservationStatus, id },
+  content: {
+    reservationId,
+    game: { homeTeamName, awayTeamName, gameStartTime, stadiumName },
+  },
 }: {
-  content: InformationCardProp;
+  content: { reservationId: number; game: InformationCardProp };
 }) {
-  const { isModalOpen, handleModalOpen, handleModalClose } = useHistoryModal(id, true);
+  const { isModalOpen, handleModalOpen, handleModalClose } = useHistoryModal(reservationId, true);
 
   const { date, hours, minutes } = extractDateAndTime(gameStartTime);
   const navigate = useNavigate();
 
   function handleInfoModalOpen() {
-    navigate(`${id}`);
+    navigate(`${reservationId}`);
     handleModalOpen();
   }
   function handleInfoModalClose() {
-    // /:id 에서 / 로 이동
+    // /:reservationId 에서 / 로 이동
     navigate(-1);
     handleModalClose();
   }
@@ -31,9 +34,9 @@ export default function InformationCard({
     <DefaultCard>
       <div className="p-[20px]">
         <div className="mb-2 border-b border-borders pb-2">
-          <span className="font-bold">
+          <p className="truncate font-bold">
             {homeTeamName} vs {awayTeamName}
-          </span>
+          </p>
           <div className="mt-3 flex items-center gap-3">
             <BsCalendar2EventFill className="size-4" />
             <div className="flex flex-col text-xs">
@@ -48,13 +51,15 @@ export default function InformationCard({
             <span className="text-xs">{stadiumName}</span>
           </div>
         </div>
-        {reservationStatus !== undefined && (
-          <button className="text-xs text-Accent" onClick={handleInfoModalOpen}>
-            상세정보
-          </button>
-        )}
+        <button className="text-xs text-Accent" onClick={handleInfoModalOpen}>
+          상세정보
+        </button>
       </div>
-      <InformationModal isOpen={isModalOpen} onClose={handleInfoModalClose} reservationId={id} />
+      <InformationModal
+        isOpen={isModalOpen}
+        onClose={handleInfoModalClose}
+        reservationId={reservationId}
+      />
     </DefaultCard>
   );
 }

--- a/src/pages/MyTicket/components/NoTicketHistory.tsx
+++ b/src/pages/MyTicket/components/NoTicketHistory.tsx
@@ -1,0 +1,15 @@
+import CalendarDelete from "@/assets/calendar-delete.svg?react";
+import { useLocation } from "react-router-dom";
+
+export default function NoTicketHistory() {
+  const { pathname } = useLocation();
+
+  return (
+    <div className="flex w-full flex-col items-center justify-center">
+      <CalendarDelete className="" />
+      <p className="font-medium">
+        {pathname.includes("my-reservations") ? "예매" : "취소"} 내역이 존재하지 않습니다!
+      </p>
+    </div>
+  );
+}

--- a/src/pages/MyTicket/components/modal/InformationModal/InformationDetail.tsx
+++ b/src/pages/MyTicket/components/modal/InformationModal/InformationDetail.tsx
@@ -1,0 +1,67 @@
+import Button from "@/common/components/atoms/Button";
+import DetailedTicket from "@/common/components/organisms/DetailedTicket";
+import ModalInfo from "@/common/components/organisms/ModalInfo";
+import useHistoryModal from "@/hooks/useHistoryModal";
+import useReservationDetails from "@/pages/MyTicket/api/useReservationDetails";
+import CancellationConfirmModal from "@/pages/MyTicket/components/modal/CancellationConfirmModal";
+interface InformationModal {
+  onClose: () => void;
+  reservationId: number;
+}
+export default function InformationDetail({ onClose, reservationId }: InformationModal) {
+  const { isModalOpen, handleModalOpen, handleModalClose } = useHistoryModal();
+  const { data, isSuccess } = useReservationDetails(reservationId);
+  const isReservationComplete = data?.reservationStatus === "COMPLETED" ? true : false;
+  return (
+    <>
+      {isSuccess && data && (
+        <div className="mx-4 flex w-full flex-col items-center">
+          <DetailedTicket
+            game={data.game}
+            isReservationComplete={isReservationComplete}
+            mySeats={data.seats}
+            totalPay={data.totalPrice}
+          />
+          <section className="flex w-full flex-col gap-4">
+            <ModalInfo
+              firstInfoPart={{
+                heading: "예매일",
+                content: data.createdAt.split("T")[0].split("-").join("."),
+              }}
+              secondInfoPart={{ heading: "예매자", content: data.memberName }}
+            />
+            <ModalInfo
+              firstInfoPart={{
+                heading: "티켓상태",
+                content: isReservationComplete ? "예매완료" : "예매취소",
+              }}
+              secondInfoPart={{ heading: "결제금액", content: data.totalPrice + "" }}
+            />
+            <ModalInfo
+              firstInfoPart={{
+                heading: "좌석",
+                content: data.seats.reduce((acc, seat, index) => {
+                  return (
+                    acc +
+                    `${seat.seatPosition} ${seat.seatRow}열 ${seat.seatNum}번 ${index < data.seats.length - 1 ? ", " : ""}`
+                  );
+                }, ""),
+                isSeat: true,
+              }}
+              secondInfoPart={{ heading: "매수", content: `${data.seats.length} 매` }}
+            />
+            <Button
+              content={isReservationComplete ? "티켓 취소" : "닫기"}
+              onClick={isReservationComplete ? handleModalOpen : onClose}
+            />
+          </section>
+          <CancellationConfirmModal
+            isOpen={isModalOpen}
+            onClose={handleModalClose}
+            reservationId={reservationId}
+          />
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/pages/MyTicket/components/modal/InformationModal/InformationDetail.tsx
+++ b/src/pages/MyTicket/components/modal/InformationModal/InformationDetail.tsx
@@ -1,4 +1,5 @@
-import Button from "@/common/components/atoms/Button";
+import { BASIC_GREY_BUTTON_STYLE, BASIC_RED_BUTTON_STYLE } from "@/common/buttonStyles";
+import BasicButton from "@/common/components/atoms/button/BasicButton";
 import DetailedTicket from "@/common/components/organisms/DetailedTicket";
 import ModalInfo from "@/common/components/organisms/ModalInfo";
 import useHistoryModal from "@/hooks/useHistoryModal";
@@ -10,8 +11,9 @@ interface InformationModal {
 }
 export default function InformationDetail({ onClose, reservationId }: InformationModal) {
   const { isModalOpen, handleModalOpen, handleModalClose } = useHistoryModal();
-  const { data, isSuccess } = useReservationDetails(reservationId);
-  const isReservationComplete = data?.reservationStatus === "COMPLETED" ? true : false;
+  const { data, isSuccess, isReservationComplete, gamePassed } =
+    useReservationDetails(reservationId);
+
   return (
     <>
       {isSuccess && data && (
@@ -50,9 +52,11 @@ export default function InformationDetail({ onClose, reservationId }: Informatio
               }}
               secondInfoPart={{ heading: "매수", content: `${data.seats.length} 매` }}
             />
-            <Button
-              content={isReservationComplete ? "티켓 취소" : "닫기"}
+            <BasicButton
+              content={isReservationComplete ? (gamePassed ? "취소 불가" : "티켓 취소") : "닫기"}
               onClick={isReservationComplete ? handleModalOpen : onClose}
+              style={isReservationComplete ? BASIC_RED_BUTTON_STYLE : BASIC_GREY_BUTTON_STYLE}
+              disabled={gamePassed && isReservationComplete}
             />
           </section>
           <CancellationConfirmModal

--- a/src/pages/MyTicket/components/modal/InformationModal/index.tsx
+++ b/src/pages/MyTicket/components/modal/InformationModal/index.tsx
@@ -1,13 +1,11 @@
 import Modal from "react-modal";
-import Button from "@/common/components/atoms/Button";
+import InformationDetail from "@/pages/MyTicket/components/modal/InformationModal/InformationDetail";
 import Loading from "@/common/components/atoms/Loading";
 import ErrorPage from "@/pages/ErrorPage";
-import CancellationConfirmModal from "@/pages/MyTicket/components/modal/CancellationConfirmModal";
-import useHistoryModal from "@/hooks/useHistoryModal";
-import DetailedTicket from "@/common/components/organisms/DetailedTicket";
-import ModalInfo from "@/common/components/organisms/ModalInfo";
+import { Suspense } from "react";
+import { ErrorBoundary } from "react-error-boundary";
+import { useQueryErrorResetBoundary } from "@tanstack/react-query";
 import ModalHeader from "@/common/components/molecules/ModalHeader";
-import useReservationDetails from "@/pages/MyTicket/api/useReservationDetails";
 
 interface InformationModal {
   isOpen: boolean;
@@ -16,63 +14,24 @@ interface InformationModal {
 }
 
 export default function InformationModal({ isOpen, onClose, reservationId }: InformationModal) {
-  const { isModalOpen, handleModalOpen, handleModalClose } = useHistoryModal();
-  const { data, error, isLoading, isSuccess } = useReservationDetails(reservationId, isOpen);
-
-  const isReservationComplete = data?.reservationStatus === "COMPLETE" ? true : false;
+  const { reset } = useQueryErrorResetBoundary();
   return (
     <Modal
       isOpen={isOpen}
       onRequestClose={onClose}
-      className="w-88 fixed left-1/2 top-1/2 flex min-h-[30rem] -translate-x-1/2 -translate-y-1/2 flex-col items-center rounded-[30px] border border-borders bg-foreground p-[40px]"
+      className="fixed left-1/2 top-1/2 flex min-h-[30rem] w-88 -translate-x-1/2 -translate-y-1/2 flex-col items-center rounded-[30px] border border-borders bg-foreground p-[40px]"
       overlayClassName="fixed inset-0 bg-black bg-opacity-30"
     >
       <ModalHeader onCloseButtonClick={onClose} content="예매 정보" />
-      {isLoading && <Loading />}
-      {error && <ErrorPage />}
-      {isSuccess && data && (
-        <div className="mx-4 flex flex-col items-center">
-          <DetailedTicket data={data} isReservationComplete={isReservationComplete} />
-          <section className="flex flex-col gap-4">
-            <ModalInfo
-              firstInfoPart={{
-                heading: "예매일",
-                content: data.createDate.split("T")[0].split("-").join("."),
-              }}
-              secondInfoPart={{ heading: "예매자", content: data.memberName }}
-            />
-            <ModalInfo
-              firstInfoPart={{
-                heading: "티켓상태",
-                content: isReservationComplete ? "예매완료" : "예매취소",
-              }}
-              secondInfoPart={{ heading: "결제금액", content: data.totalPrice }}
-            />
-            <ModalInfo
-              firstInfoPart={{
-                heading: "좌석",
-                content: data.seat.reduce((acc, seat, index) => {
-                  return (
-                    acc +
-                    `${seat.seatPosition}석, ${seat.seatRow}, ${seat.seatNumber} ${index < data.seat.length - 1 ? " | " : ""}`
-                  );
-                }, ""),
-                isSeat: true,
-              }}
-              secondInfoPart={{ heading: "매수", content: `${data.seat.length} 매` }}
-            />
-            <Button
-              content={isReservationComplete ? "티켓 취소" : "닫기"}
-              onClick={isReservationComplete ? handleModalOpen : onClose}
-            />
-          </section>
-          <CancellationConfirmModal
-            isOpen={isModalOpen}
-            onClose={handleModalClose}
-            reservationId={reservationId}
-          />
-        </div>
-      )}
+      <Suspense fallback={<Loading />}>
+        <ErrorBoundary
+          FallbackComponent={ErrorPage}
+          onReset={reset}
+          resetKeys={[location.pathname]}
+        >
+          <InformationDetail onClose={onClose} reservationId={reservationId} />
+        </ErrorBoundary>
+      </Suspense>
     </Modal>
   );
 }

--- a/src/pages/MyTicket/hooks/useInfiniteScroll.ts
+++ b/src/pages/MyTicket/hooks/useInfiniteScroll.ts
@@ -23,24 +23,28 @@ interface UseInfiniteScrollProps {
   >;
   hasNextPage: boolean;
   isFetchingNextPage: boolean;
+  totalElements: number;
 }
 
 export default function useInfiniteScroll({
   onLoadMore,
   hasNextPage,
   isFetchingNextPage,
+  totalElements,
 }: UseInfiniteScrollProps) {
   const { ref, inView } = useInView({
     threshold: 1,
   });
 
   useEffect(() => {
-    if (inView && hasNextPage && !isFetchingNextPage) {
-      onLoadMore();
-    } else if (!hasNextPage) {
-      alertToast("마지막 자료입니다!", "info", "bottom");
+    if (totalElements) {
+      if (inView && hasNextPage && !isFetchingNextPage) {
+        onLoadMore();
+      } else if (!hasNextPage) {
+        alertToast("마지막 자료입니다!", "info", "bottom");
+      }
     }
-  }, [inView, onLoadMore, hasNextPage, isFetchingNextPage]);
+  }, [inView, onLoadMore, hasNextPage, isFetchingNextPage, totalElements]);
 
   return ref;
 }

--- a/src/pages/MyTicket/hooks/useInfiniteScroll.ts
+++ b/src/pages/MyTicket/hooks/useInfiniteScroll.ts
@@ -1,0 +1,41 @@
+import { GameHistoryType, PageInfoProps } from "@/common/types/type";
+import alertToast from "@/common/utils/alertToast";
+import {
+  FetchNextPageOptions,
+  InfiniteQueryObserverResult,
+  InfiniteData,
+} from "@tanstack/react-query";
+import { useEffect } from "react";
+import { useInView } from "react-intersection-observer";
+
+interface UseInfiniteScrollProps {
+  onLoadMore: (options?: FetchNextPageOptions) => Promise<
+    InfiniteQueryObserverResult<
+      InfiniteData<
+        {
+          content: GameHistoryType;
+          pageInfo: PageInfoProps;
+        },
+        unknown
+      >,
+      Error
+    >
+  >;
+  hasNextPage: boolean;
+}
+
+export default function useInfiniteScroll({ onLoadMore, hasNextPage }: UseInfiniteScrollProps) {
+  const { ref, inView } = useInView({
+    threshold: 1,
+  });
+
+  useEffect(() => {
+    if (inView && hasNextPage) {
+      onLoadMore();
+    } else if (!hasNextPage) {
+      alertToast("마지막 자료입니다!", "info", "bottom");
+    }
+  }, [inView, onLoadMore, hasNextPage]);
+
+  return ref;
+}

--- a/src/pages/MyTicket/hooks/useInfiniteScroll.ts
+++ b/src/pages/MyTicket/hooks/useInfiniteScroll.ts
@@ -22,20 +22,25 @@ interface UseInfiniteScrollProps {
     >
   >;
   hasNextPage: boolean;
+  isFetchingNextPage: boolean;
 }
 
-export default function useInfiniteScroll({ onLoadMore, hasNextPage }: UseInfiniteScrollProps) {
+export default function useInfiniteScroll({
+  onLoadMore,
+  hasNextPage,
+  isFetchingNextPage,
+}: UseInfiniteScrollProps) {
   const { ref, inView } = useInView({
     threshold: 1,
   });
 
   useEffect(() => {
-    if (inView && hasNextPage) {
+    if (inView && hasNextPage && !isFetchingNextPage) {
       onLoadMore();
     } else if (!hasNextPage) {
       alertToast("마지막 자료입니다!", "info", "bottom");
     }
-  }, [inView, onLoadMore, hasNextPage]);
+  }, [inView, onLoadMore, hasNextPage, isFetchingNextPage]);
 
   return ref;
 }

--- a/src/pages/MyTicket/index.tsx
+++ b/src/pages/MyTicket/index.tsx
@@ -10,6 +10,7 @@ export default function MyTicket() {
   const ref = useInfiniteScroll({
     onLoadMore: fetchNextPage,
     hasNextPage,
+    isFetchingNextPage,
   });
 
   return (
@@ -28,7 +29,7 @@ export default function MyTicket() {
         )}
       </section>
       {isFetchingNextPage && <Loading />}
-      <div className="h-80" ref={ref} />
+      <div className="h-40" ref={ref} />
     </>
   );
 }

--- a/src/pages/MyTicket/index.tsx
+++ b/src/pages/MyTicket/index.tsx
@@ -7,16 +7,17 @@ import useInfiniteScroll from "@/pages/MyTicket/hooks/useInfiniteScroll";
 
 export default function MyTicket() {
   const { data, fetchNextPage, isFetchingNextPage, hasNextPage } = useMyTicketHistory();
+  const totalElements = data.pages[0].pageInfo.totalElements;
   const ref = useInfiniteScroll({
     onLoadMore: fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
+    totalElements,
   });
-
   return (
     <>
-      <section className={`${data ? "grid grid-cols-3 gap-4" : "flex flex-1"}`}>
-        {data ? (
+      <section className={`${totalElements ? "grid grid-cols-3 gap-4" : "flex flex-1"}`}>
+        {totalElements ? (
           data.pages.map((page, pageIndex) => (
             <React.Fragment key={pageIndex}>
               {page.content.map((item) => (
@@ -29,7 +30,7 @@ export default function MyTicket() {
         )}
       </section>
       {isFetchingNextPage && <Loading />}
-      <div className="h-40" ref={ref} />
+      {totalElements ? <div className="h-40" ref={ref} /> : null}
     </>
   );
 }

--- a/src/pages/MyTicket/index.tsx
+++ b/src/pages/MyTicket/index.tsx
@@ -1,16 +1,17 @@
 import InformationCard from "@/pages/MyTicket/components/InformationCard";
 import useMyTicketHistory from "@/pages/MyTicket/api/useMyTicketHistory";
+import NoTicketHistory from "@/pages/MyTicket/components/NoTicketHistory";
 
 export default function MyTicket() {
   const { data } = useMyTicketHistory();
 
   return (
-    <section className="grid grid-cols-3 flex-wrap gap-4">
+    <section className={`${data?.length ? "grid grid-cols-8 gap-4" : "flex flex-1"}`}>
       {/** InformationCard 혹은 정보 없음을 표시할 것. */}
       {data.length ? (
         data.map((el) => <InformationCard content={el} key={el.gameId} />)
       ) : (
-        <span>조회 내역이 없습니다!</span>
+        <NoTicketHistory />
       )}
     </section>
   );

--- a/src/pages/MyTicket/index.tsx
+++ b/src/pages/MyTicket/index.tsx
@@ -1,20 +1,17 @@
 import InformationCard from "@/pages/MyTicket/components/InformationCard";
 import useMyTicketHistory from "@/pages/MyTicket/api/useMyTicketHistory";
 import NoTicketHistory from "@/pages/MyTicket/components/NoTicketHistory";
-import React, { useEffect } from "react";
-import { useInView } from "react-intersection-observer";
+import React from "react";
 import Loading from "@/common/components/atoms/Loading";
+import useInfiniteScroll from "@/pages/MyTicket/hooks/useInfiniteScroll";
 
 export default function MyTicket() {
   const { data, fetchNextPage, isFetchingNextPage, hasNextPage } = useMyTicketHistory();
-  const { ref, inView } = useInView({
-    threshold: 1,
+  const ref = useInfiniteScroll({
+    onLoadMore: fetchNextPage,
+    hasNextPage,
   });
-  useEffect(() => {
-    if (inView && hasNextPage) {
-      fetchNextPage();
-    }
-  }, [inView, fetchNextPage, hasNextPage]);
+
   return (
     <>
       <section className={`${data ? "grid grid-cols-3 gap-4" : "flex flex-1"}`}>

--- a/src/pages/MyTicket/index.tsx
+++ b/src/pages/MyTicket/index.tsx
@@ -1,14 +1,22 @@
 import InformationCard from "@/pages/MyTicket/components/InformationCard";
 import useMyTicketHistory from "@/pages/MyTicket/api/useMyTicketHistory";
 import NoTicketHistory from "@/pages/MyTicket/components/NoTicketHistory";
+import React from "react";
 
 export default function MyTicket() {
-  const { data } = useMyTicketHistory();
+  const { data, fetchNextPage } = useMyTicketHistory();
+  console.log("data.pages[0].content = ", data?.pages[0].content);
+
   return (
-    <section className={`${data?.length ? "grid grid-cols-3 gap-4" : "flex flex-1"}`}>
-      {/** InformationCard 혹은 정보 없음을 표시할 것. */}
-      {data.length ? (
-        data.map((el) => <InformationCard content={el} key={el.reservationId} />)
+    <section className={`${data ? "grid grid-cols-3 gap-4" : "flex flex-1"}`}>
+      {data ? (
+        data.pages.map((page, pageIndex) => (
+          <React.Fragment key={pageIndex}>
+            {page.content.map((item) => (
+              <InformationCard content={item} key={item.reservationId} />
+            ))}
+          </React.Fragment>
+        ))
       ) : (
         <NoTicketHistory />
       )}

--- a/src/pages/MyTicket/index.tsx
+++ b/src/pages/MyTicket/index.tsx
@@ -1,25 +1,39 @@
 import InformationCard from "@/pages/MyTicket/components/InformationCard";
 import useMyTicketHistory from "@/pages/MyTicket/api/useMyTicketHistory";
 import NoTicketHistory from "@/pages/MyTicket/components/NoTicketHistory";
-import React from "react";
+import React, { useEffect } from "react";
+import { useInView } from "react-intersection-observer";
+import Loading from "@/common/components/atoms/Loading";
 
 export default function MyTicket() {
-  const { data, fetchNextPage } = useMyTicketHistory();
-  console.log("data.pages[0].content = ", data?.pages[0].content);
-
+  const { data, fetchNextPage, status, isFetchingNextPage, hasNextPage } = useMyTicketHistory();
+  console.log(data);
+  const { ref, inView } = useInView({
+    threshold: 1,
+  });
+  useEffect(() => {
+    if (inView) {
+      fetchNextPage();
+    }
+  }, [inView, fetchNextPage]);
+  console.log(hasNextPage);
   return (
-    <section className={`${data ? "grid grid-cols-3 gap-4" : "flex flex-1"}`}>
-      {data ? (
-        data.pages.map((page, pageIndex) => (
-          <React.Fragment key={pageIndex}>
-            {page.content.map((item) => (
-              <InformationCard content={item} key={item.reservationId} />
-            ))}
-          </React.Fragment>
-        ))
-      ) : (
-        <NoTicketHistory />
-      )}
-    </section>
+    <>
+      <section className={`${data ? "grid grid-cols-3 gap-4" : "flex flex-1"}`}>
+        {data ? (
+          data.pages.map((page, pageIndex) => (
+            <React.Fragment key={pageIndex}>
+              {page.content.map((item) => (
+                <InformationCard content={item} key={item.reservationId} />
+              ))}
+            </React.Fragment>
+          ))
+        ) : (
+          <NoTicketHistory />
+        )}
+      </section>
+      {isFetchingNextPage && <Loading />}
+      <div className="h-80" ref={ref} />
+    </>
   );
 }

--- a/src/pages/MyTicket/index.tsx
+++ b/src/pages/MyTicket/index.tsx
@@ -5,13 +5,13 @@ export default function MyTicket() {
   const { data } = useMyTicketHistory();
 
   return (
-    <div className="grid grid-cols-3 flex-wrap gap-4">
+    <section className="grid grid-cols-3 flex-wrap gap-4">
       {/** InformationCard 혹은 정보 없음을 표시할 것. */}
       {data.length ? (
         data.map((el) => <InformationCard content={el} key={el.gameId} />)
       ) : (
         <span>조회 내역이 없습니다!</span>
       )}
-    </div>
+    </section>
   );
 }

--- a/src/pages/MyTicket/index.tsx
+++ b/src/pages/MyTicket/index.tsx
@@ -6,17 +6,15 @@ import { useInView } from "react-intersection-observer";
 import Loading from "@/common/components/atoms/Loading";
 
 export default function MyTicket() {
-  const { data, fetchNextPage, status, isFetchingNextPage, hasNextPage } = useMyTicketHistory();
-  console.log(data);
+  const { data, fetchNextPage, isFetchingNextPage, hasNextPage } = useMyTicketHistory();
   const { ref, inView } = useInView({
     threshold: 1,
   });
   useEffect(() => {
-    if (inView) {
+    if (inView && hasNextPage) {
       fetchNextPage();
     }
-  }, [inView, fetchNextPage]);
-  console.log(hasNextPage);
+  }, [inView, fetchNextPage, hasNextPage]);
   return (
     <>
       <section className={`${data ? "grid grid-cols-3 gap-4" : "flex flex-1"}`}>

--- a/src/pages/MyTicket/index.tsx
+++ b/src/pages/MyTicket/index.tsx
@@ -4,12 +4,11 @@ import NoTicketHistory from "@/pages/MyTicket/components/NoTicketHistory";
 
 export default function MyTicket() {
   const { data } = useMyTicketHistory();
-
   return (
-    <section className={`${data?.length ? "grid grid-cols-8 gap-4" : "flex flex-1"}`}>
+    <section className={`${data?.length ? "grid grid-cols-3 gap-4" : "flex flex-1"}`}>
       {/** InformationCard 혹은 정보 없음을 표시할 것. */}
       {data.length ? (
-        data.map((el) => <InformationCard content={el} key={el.gameId} />)
+        data.map((el) => <InformationCard content={el} key={el.reservationId} />)
       ) : (
         <NoTicketHistory />
       )}


### PR DESCRIPTION
## 이슈와 연결하기

Issue Number: #83

<br>

## 무엇이 추가 되었나요?
### `NoTicketHistory` 컴포넌트 구현
예매/취소 내역이 없을 때 렌더링되는 `NoTicketHistory` 컴포넌트 구현했습니다.
```tsx
export default function NoTicketHistory() {
  const { pathname } = useLocation();

  return (
    <div className="flex w-full flex-col items-center justify-center">
      <CalendarDelete className="" />
      <p className="font-medium">
        {pathname.includes("my-reservations") ? "예매" : "취소"} 내역이 존재하지 않습니다!
      </p>
    </div>
  );
```
<img width="1022" alt="스크린샷 2024-11-25 오후 2 53 17" src="https://github.com/user-attachments/assets/b4a18b2f-633e-4bd4-9b76-b749782f9417">

### 무한 스크롤 구현
티켓 예매 및 취소 내역 구현에 무한 스크롤을 구현했습니다.

```tsx
// MyTicket.tsx
export default function MyTicket() {
  const { data, fetchNextPage, isFetchingNextPage, hasNextPage } = useMyTicketHistory();
  const totalElements = data.pages[0].pageInfo.totalElements;
  const ref = useInfiniteScroll({
    onLoadMore: fetchNextPage,
    hasNextPage,
    isFetchingNextPage,
    totalElements,
  });
  return (
    <>
      <section className={`${totalElements ? "grid grid-cols-3 gap-4" : "flex flex-1"}`}>
        {totalElements ? (
          data.pages.map((page, pageIndex) => (
            <React.Fragment key={pageIndex}>
              {page.content.map((item) => (
                <InformationCard content={item} key={item.reservationId} />
              ))}
            </React.Fragment>
          ))
        ) : (
          <NoTicketHistory />
        )}
      </section>
      {isFetchingNextPage && <Loading />}
      {totalElements ? <div className="h-40" ref={ref} /> : null}
    </>
  );
}
```

```ts
// useMyTicketHistory.ts
export default function useMyTicketHistory() {
  const location = useLocation().pathname;
  const param = location.includes("/profile/my-tickets/my-reservations") ? "COMPLETE" : "CANCEL";

  return useSuspenseInfiniteQuery<{ content: GameHistoryType; pageInfo: PageInfoProps }>({
    queryKey: ["myReservations", param],
    queryFn: async ({ pageParam }) => {
      const res = await axiosInstance.get(`reservation?status=${param}&page=${pageParam}`);
      return res.data;
    },
    initialPageParam: 1,
    getNextPageParam: (lastPage) => {
      return lastPage.pageInfo.totalPages > lastPage.pageInfo.page
        ? lastPage.pageInfo.page + 1
        : null;
    },
  });
}
```
기존 서스펜스를 활용하기 위해 `useSuspenseInfiniteQuery` 를 사용했습니다. `initialPageParam` 는 시작 페이지의 번호(1번), `getNextPageParam` 는 다음 페이지수를 가져오는 로직입니다. 여기서는 총 페이지가 현재 페이지보다 클 경우 현재 페이지 + 1 을 다음 페이지로 했고, 그러지 않을 경우 `null` 을 반환해 더이상 페이지가 없도록 설정 했습니다.

```ts
// useInfiniteScroll.ts
export default function useInfiniteScroll({
  onLoadMore,
  hasNextPage,
  isFetchingNextPage,
  totalElements,
}: UseInfiniteScrollProps) {
  const { ref, inView } = useInView({
    threshold: 1,
  });

  useEffect(() => {
    if (totalElements) {
      if (inView && hasNextPage && !isFetchingNextPage) {
        onLoadMore();
      } else if (!hasNextPage) {
        alertToast("마지막 자료입니다!", "info", "bottom");
      }
    }
  }, [inView, onLoadMore, hasNextPage, isFetchingNextPage, totalElements]);

  return ref;
}
```
일정 컨텐츠에 도달하면 다음 데이터를 불러오는 커스텀 훅입니다. react-intersection-observer 라는 라이브러리를 설치하고 `useInView` 라는 훅을 사용했는데, 해당 훅은 `ref` 를 가진 요소가 현재 뷰포트(시야)에 들어왔는지를 확인하며 시야에 들어왔다면 `inView` 가 `true`입니다. `threshold` 옵션은 해당 요소의 몇%가 시야에 들어왔을 떄 `inView` 를 `true` 로 바꾸냐인데, 0~1 사이의 수를 전달하면 됩니다. 여기서는 1 을 전달했고, 요소 전부가 시야에 들어와야 `inView` 가 `true` 가 됩니다.
`useEffect` 에 전달된 콜백에서 데이터를 불러올지 말지를 결정합니다. `totalElements` 가 있을 경우, 그러니까 애초에 내역이 있을 경우 마지막 요소가 시야에 있고, 다음 페이지도 있으며, 현재 다음 페이지의 데이터를 가져오는 중이 아닐 때만 다음 데이터를 가져옵니다. 만약 다음 페이지가 없다면 토스트를 통해 알립니다.
해당 훅은 `ref` 를 반환하고, `ref` 를 요소의 `ref` 에 전달하면 됩니다. 여기서는 `<div>` 를 만들고 `ref` 를 전달했습니다(`MyTicket` 마지막 줄 참고).


<br>

## 기타 정보

<br>