### PR TITLE
메인페이지에서 예매하기버튼 수정, 좌석번호수정

### DIFF
--- a/src/common/components/atoms/button/LinkButton.tsx
+++ b/src/common/components/atoms/button/LinkButton.tsx
@@ -1,13 +1,15 @@
+import { BaseMatch } from "@/common/types/matchTypes";
 import { Link } from "react-router-dom";
 
 interface LinkButtonProps {
   content: string;
   linkTo: string;
   style: string;
+  state?: { match: BaseMatch };
 }
-export default function LinkButton({ content, linkTo, style }: LinkButtonProps) {
+export default function LinkButton({ content, linkTo, state, style }: LinkButtonProps) {
   return (
-    <Link to={linkTo} className={`transition-all duration-300 ${style}`}>
+    <Link to={linkTo} className={`transition-all duration-300 ${style}`} state={state}>
       {content}
     </Link>
   );

--- a/src/common/types/seatTypes.ts
+++ b/src/common/types/seatTypes.ts
@@ -1,5 +1,6 @@
 export interface Seat {
   id: number;
+  seatNumber: number;
   isReserved: boolean;
   isSelected: boolean;
   price: number;
@@ -53,5 +54,5 @@ export interface SeatsProps {
   seatPrice: number;
   seatPosition: string;
   seatRow: number;
-  seatNumer: number;
+  seatNumber: number;
 }

--- a/src/pages/Home/components/MainMatch/MainMatchInfo/index.tsx
+++ b/src/pages/Home/components/MainMatch/MainMatchInfo/index.tsx
@@ -26,6 +26,15 @@ export default function MainMatchInfo({
 >) {
   const isTicketOnSale = isSaleTimeOn(timeOnSale, timeOffSale);
   const { month, day, weekday, hours, minutes } = extractDateData(timeOffSale);
+  const match = {
+    awayTeamName,
+    gameId,
+    gameStartTime,
+    homeTeamName,
+    stadiumName,
+    timeOffSale,
+    timeOnSale,
+  };
   return (
     <div className="flex w-full flex-col items-center justify-center rounded border border-borders bg-foreground p-4">
       <MatchDate gameStartTime={gameStartTime} />
@@ -35,6 +44,7 @@ export default function MainMatchInfo({
         <LinkButton
           content={`${month}/${day}(${weekday}) ${hours}:${minutes}까지 예매 가능`}
           linkTo={`/reservation/${gameId}`}
+          state={{ match: match }}
           style="w-full px-3 py-1 rounded-[10px] bg-Accent text-[16px] text-center text-foreground hover:bg-button-hovered disabled:cursor-not-allowed disabled:bg-disabled-button"
         />
       ) : (

--- a/src/pages/Home/components/WeeklyMatches/MatchCard/index.tsx
+++ b/src/pages/Home/components/WeeklyMatches/MatchCard/index.tsx
@@ -21,6 +21,15 @@ export default function MatchCard({ data }: { data: MatchData }) {
 
   const isTicketOnSale = isSaleTimeOn(timeOnSale, timeOffSale);
   const { month, day, weekday, hours, minutes } = extractDateData(timeOffSale);
+  const match = {
+    awayTeamName,
+    gameId,
+    gameStartTime,
+    homeTeamName,
+    stadiumName,
+    timeOffSale,
+    timeOnSale,
+  };
   return (
     <div className="flex flex-col items-center justify-between rounded-2xl border border-borders bg-foreground p-4">
       {/* 경기 카드*/}
@@ -42,6 +51,7 @@ export default function MatchCard({ data }: { data: MatchData }) {
         <LinkButton
           content={`${month}/${day}(${weekday}) ${hours}:${minutes}까지 예매 가능`}
           linkTo={`/reservation/${gameId}`}
+          state={{ match: match }}
           style="btn-red"
         />
       )}

--- a/src/pages/Reservation/components/seats/SectionOfSeats.tsx
+++ b/src/pages/Reservation/components/seats/SectionOfSeats.tsx
@@ -31,6 +31,7 @@ export default function SectionOfSeats({
           }
           acc[seat.seatPosition].push({
             id: seat.id,
+            seatNumber: seat.seatNumber,
             isReserved: seat.status === "RESERVED",
             isSelected: false,
             price: seat.seatPrice,
@@ -94,7 +95,7 @@ export default function SectionOfSeats({
                 : "bg-text-primary opacity-50"
           }`}
         >
-          {seat.id}
+          {seat.seatNumber}
         </div>
       ))}
     </div>

--- a/src/pages/Reservation/components/seats/SelectedSeat.tsx
+++ b/src/pages/Reservation/components/seats/SelectedSeat.tsx
@@ -22,7 +22,7 @@ export default function SelectedSeats({
   const seatIds = selectedSeats.map((seat) => seat.id);
   const totalPay = selectedSeats.reduce((total) => total + seatPrice, 0);
   const mySeats = selectedSeats.map((seat: Seat) => {
-    return `${selectedSection} ${Math.ceil(seat.id / 10)}열 ${seat.id}번`;
+    return `${selectedSection} ${Math.ceil(seat.seatNumber / 10)}열 ${seat.seatNumber}번`;
   });
 
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -50,7 +50,7 @@ export default function SelectedSeats({
             className="m-1 flex flex-col items-center rounded-md border border-text-tertiary bg-foreground p-1 text-xs"
           >
             <h3>
-              {selectedSection} {Math.ceil(seat.id / 10)}열 {seat.id}번
+              {selectedSection} {Math.ceil(seat.seatNumber / 10)}열 {seat.seatNumber}번
             </h3>
             <h3>{seatPrice}원</h3>
           </div>


### PR DESCRIPTION
## 이슈와 연결하기 

Issue Number: #91 

<br> 

## 무엇이 추가 되었나요? 
- 메인페이지의 `LinkButton`에 `state` 추가
  - 기존 예매페이지에서 useLocation을 활용하여 state를 참조하고 있었으나, 메인 페이지의 Link 버튼에서 state를 전달하지 않아 데이터가 없거나 오류가 발생하는 문제가 있었습니다.
 ```tsx
const match = {
    awayTeamName,
    gameId,
    gameStartTime,
    homeTeamName,
    stadiumName,
    timeOffSale,
    timeOnSale,
  };

<LinkButton state={{ match: match }} />
```

- 예매페이지에서 좌석번호를 id가 아닌 seatNumber로 가져오도록 변경하였습니다.
<br> 

## 기타 정보

 <br>