### PR TITLE
마이페이지 제목 밑 설명 디자인 수정

### DIFF
--- a/src/common/components/atoms/AuthFirstHeading.tsx
+++ b/src/common/components/atoms/AuthFirstHeading.tsx
@@ -1,3 +1,3 @@
 export default function AuthFirstHeading({ content }: { content: string }) {
-  return <h1 className="text-2xl font-bold">{content}</h1>;
+  return <h1 className="text-[40px] font-semibold">{content}</h1>;
 }

--- a/src/common/layouts/AuthLayout/index.tsx
+++ b/src/common/layouts/AuthLayout/index.tsx
@@ -15,7 +15,7 @@ export default function AuthLayout() {
     <div>
       <div className="flex flex-col items-center justify-center">
         <AuthFirstHeading content={heading} />
-        <span className="mb-5 font-medium text-text-tertiary">{paragraph}</span>
+        <span className="mb-5 text-[20px] text-text-primary opacity-50">{paragraph}</span>
         {location.pathname.includes("/my-tickets") && (
           <div className="mb-4 flex gap-4">
             {myTicketMenu.map((menu) => (


### PR DESCRIPTION
## 이슈와 연결하기

Issue Number: #93

<br>

## 무엇이 추가 되었나요?
마이페이지의 제목 및 설명을 위에서 아래로 수정했습니다.
<img width="341" alt="스크린샷 2025-01-13 오후 4 56 44" src="https://github.com/user-attachments/assets/2f32bcd3-65ec-47b7-8821-4b5b98717b1b" />

<img width="488" alt="스크린샷 2025-01-13 오후 4 56 51" src="https://github.com/user-attachments/assets/09edb4ca-6709-4c97-8777-b32c3807e92f" />

<br>

## 기타 정보

<br>